### PR TITLE
fix: make values.cue optional when --values flags are provided

### DIFF
--- a/internal/build/testdata/external-values.cue
+++ b/internal/build/testdata/external-values.cue
@@ -1,0 +1,7 @@
+package testmodule
+
+values: {
+	image:    "nginx:1.27"
+	replicas: 3
+	port:     9090
+}

--- a/internal/build/testdata/test-module-no-values/cue.mod/module.cue
+++ b/internal/build/testdata/test-module-no-values/cue.mod/module.cue
@@ -1,0 +1,3 @@
+module: "example.com/test-module-no-values@v0"
+
+language: version: "v0.15.0"

--- a/internal/build/testdata/test-module-no-values/module.cue
+++ b/internal/build/testdata/test-module-no-values/module.cue
@@ -1,0 +1,49 @@
+package testmodule
+
+// Module metadata
+metadata: {
+	name:             "test-module-no-values"
+	version:          "1.0.0"
+	fqn:              "example.com/test-module-no-values@v0#test-module-no-values"
+	defaultNamespace: "default"
+	labels: {
+		"module.opmodel.dev/name":    metadata.name
+		"module.opmodel.dev/version": metadata.version
+	}
+}
+
+// Configuration schema — no defaults, must be provided via --values flag
+#config: {
+	image:    string
+	replicas: int & >=1
+	port:     int | *8080
+}
+
+// Component definitions
+#components: {
+	web: {
+		metadata: {
+			name: "web"
+			labels: {
+				"workload-type": "stateless"
+			}
+		}
+		#resources: {
+			"opmodel.dev/resources/Container@v0": {
+				image:    #config.image
+				replicas: #config.replicas
+			}
+		}
+		#traits: {
+			"opmodel.dev/traits/Expose@v0": {
+				port: #config.port
+			}
+		}
+		spec: {
+			container: {
+				image: #config.image
+			}
+			replicas: #config.replicas
+		}
+	}
+}

--- a/internal/build/testdata/test-module-values-only/cue.mod/module.cue
+++ b/internal/build/testdata/test-module-values-only/cue.mod/module.cue
@@ -1,0 +1,3 @@
+module: "example.com/test-module-values-only@v0"
+
+language: version: "v0.15.0"

--- a/internal/build/testdata/test-module-values-only/module.cue
+++ b/internal/build/testdata/test-module-values-only/module.cue
@@ -1,0 +1,52 @@
+package testmodule
+
+// Module metadata
+metadata: {
+	name:             "test-module-values-only"
+	version:          "1.0.0"
+	fqn:              "example.com/test-module-values-only@v0#test-module-values-only"
+	defaultNamespace: "default"
+	labels: {
+		"module.opmodel.dev/name":    metadata.name
+		"module.opmodel.dev/version": metadata.version
+	}
+}
+
+// Configuration schema
+#config: {
+	image:    string
+	replicas: int & >=1
+	port:     int | *8080
+}
+
+// NOTE: values are defined ONLY in values.cue (not here) to support
+// clean override via --values flag.
+
+// Component definitions
+#components: {
+	web: {
+		metadata: {
+			name: "web"
+			labels: {
+				"workload-type": "stateless"
+			}
+		}
+		#resources: {
+			"opmodel.dev/resources/Container@v0": {
+				image:    #config.image
+				replicas: #config.replicas
+			}
+		}
+		#traits: {
+			"opmodel.dev/traits/Expose@v0": {
+				port: #config.port
+			}
+		}
+		spec: {
+			container: {
+				image: #config.image
+			}
+			replicas: #config.replicas
+		}
+	}
+}

--- a/internal/build/testdata/test-module-values-only/values.cue
+++ b/internal/build/testdata/test-module-values-only/values.cue
@@ -1,0 +1,7 @@
+package testmodule
+
+values: {
+	image:    "nginx:1.25"
+	replicas: 2
+	port:     8080
+}

--- a/internal/build/values_resolution_test.go
+++ b/internal/build/values_resolution_test.go
@@ -1,0 +1,204 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opmodel/cli/internal/config"
+)
+
+// testdataDir returns the absolute path to a testdata fixture directory.
+func testdataDir(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return dir
+}
+
+// testdataFile returns the absolute path to a testdata file.
+func testdataFile(t *testing.T, name string) string {
+	t.Helper()
+	f, err := filepath.Abs(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return f
+}
+
+// ----- resolveModulePath tests -----
+
+func TestResolveModulePath_WithoutValuesCue(t *testing.T) {
+	// A module directory without values.cue should be accepted by
+	// resolveModulePath — values.cue existence is no longer its concern.
+	p := &pipeline{}
+	dir := testdataDir(t, "test-module-no-values")
+
+	got, err := p.resolveModulePath(dir)
+	require.NoError(t, err)
+	assert.Equal(t, dir, got)
+}
+
+func TestResolveModulePath_WithValuesCue(t *testing.T) {
+	// A module directory WITH values.cue should still work fine.
+	p := &pipeline{}
+	dir := testdataDir(t, "test-module")
+
+	got, err := p.resolveModulePath(dir)
+	require.NoError(t, err)
+	assert.Equal(t, dir, got)
+}
+
+func TestResolveModulePath_MissingDirectory(t *testing.T) {
+	p := &pipeline{}
+	_, err := p.resolveModulePath("/nonexistent/path")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "module directory not found")
+}
+
+func TestResolveModulePath_MissingCueMod(t *testing.T) {
+	// A directory that exists but has no cue.mod/
+	dir := t.TempDir()
+	p := &pipeline{}
+
+	_, err := p.resolveModulePath(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing cue.mod/")
+}
+
+// ----- Render() values.cue conditional check tests -----
+
+func TestRender_NoValuesCue_NoValuesFlag_ReturnsError(t *testing.T) {
+	// When no --values flags are provided AND values.cue is missing on disk,
+	// Render should fail with a clear error message.
+	cueCtx := cuecontext.New()
+	cfg := &config.OPMConfig{
+		CueContext: cueCtx,
+		Registry:   "",
+	}
+	p := NewPipeline(cfg).(*pipeline)
+	dir := testdataDir(t, "test-module-no-values")
+
+	_, err := p.Render(t.Context(), RenderOptions{
+		ModulePath: dir,
+		Name:       "test",
+		Namespace:  "default",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "values.cue not found")
+	assert.Contains(t, err.Error(), "--values flag")
+}
+
+func TestRender_NoValuesCue_WithValuesFlag_SkipsValuesCueCheck(t *testing.T) {
+	// When --values flags ARE provided, the values.cue existence check
+	// should be skipped. The pipeline may fail later (e.g., no providers),
+	// but it must NOT fail with "values.cue not found".
+	cueCtx := cuecontext.New()
+	cfg := &config.OPMConfig{
+		CueContext: cueCtx,
+		Registry:   "",
+	}
+	p := NewPipeline(cfg).(*pipeline)
+	dir := testdataDir(t, "test-module-no-values")
+	valuesFile := testdataFile(t, "external-values.cue")
+
+	_, err := p.Render(t.Context(), RenderOptions{
+		ModulePath: dir,
+		Name:       "test-release",
+		Namespace:  "default",
+		Values:     []string{valuesFile},
+	})
+	// The pipeline may fail at provider loading (expected in unit tests),
+	// but it must NOT fail with "values.cue not found".
+	if err != nil {
+		assert.NotContains(t, err.Error(), "values.cue not found",
+			"should not require values.cue when --values flag is provided")
+	}
+}
+
+func TestRender_WithValuesCue_NoValuesFlag_SkipsValuesCueCheck(t *testing.T) {
+	// When values.cue exists and no --values flags: should pass the values
+	// check and proceed. May fail later (e.g., no providers).
+	cueCtx := cuecontext.New()
+	cfg := &config.OPMConfig{
+		CueContext: cueCtx,
+		Registry:   "",
+	}
+	p := NewPipeline(cfg).(*pipeline)
+	dir := testdataDir(t, "test-module")
+
+	_, err := p.Render(t.Context(), RenderOptions{
+		ModulePath: dir,
+		Name:       "test-release",
+		Namespace:  "default",
+	})
+	// Should not fail with "values.cue not found"
+	if err != nil {
+		assert.NotContains(t, err.Error(), "values.cue not found")
+	}
+}
+
+// ----- ReleaseBuilder.Build() tests -----
+
+func TestBuild_StubsValuesCue_WhenValuesFlagsProvided(t *testing.T) {
+	// When valuesFiles are passed to Build() and values.cue exists on disk,
+	// the on-disk values.cue should be replaced with a stub so the external
+	// values take precedence without conflict.
+	//
+	// Uses test-module-values-only where values are ONLY in values.cue
+	// (not duplicated in module.cue), so the stub effectively removes them.
+	cueCtx := cuecontext.New()
+	b := NewReleaseBuilder(cueCtx, "")
+	dir := testdataDir(t, "test-module-values-only")
+	valuesFile := testdataFile(t, "external-values.cue")
+
+	// Verify values.cue exists on disk (precondition)
+	_, err := os.Stat(filepath.Join(dir, "values.cue"))
+	require.NoError(t, err, "precondition: values.cue should exist on disk")
+
+	release, err := b.Build(dir, ReleaseOptions{
+		Name:      "test-release",
+		Namespace: "default",
+		PkgName:   "testmodule",
+	}, []string{valuesFile})
+	require.NoError(t, err)
+	assert.NotNil(t, release)
+	assert.Equal(t, "test-release", release.Metadata.Name)
+}
+
+func TestBuild_NoValuesCue_WithValuesFlag_Succeeds(t *testing.T) {
+	// Build() should succeed for a module without values.cue when external
+	// values files are provided.
+	cueCtx := cuecontext.New()
+	b := NewReleaseBuilder(cueCtx, "")
+	dir := testdataDir(t, "test-module-no-values")
+	valuesFile := testdataFile(t, "external-values.cue")
+
+	release, err := b.Build(dir, ReleaseOptions{
+		Name:      "test-release",
+		Namespace: "default",
+		PkgName:   "testmodule",
+	}, []string{valuesFile})
+	require.NoError(t, err)
+	assert.NotNil(t, release)
+	assert.Equal(t, "test-release", release.Metadata.Name)
+}
+
+func TestBuild_WithValuesCue_NoValuesFlag_Succeeds(t *testing.T) {
+	// Build() with values.cue on disk and no --values flags should
+	// work exactly as before (regression test).
+	cueCtx := cuecontext.New()
+	b := NewReleaseBuilder(cueCtx, "")
+	dir := testdataDir(t, "test-module")
+
+	release, err := b.Build(dir, ReleaseOptions{
+		Name:      "test-release",
+		Namespace: "default",
+		PkgName:   "testmodule",
+	}, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, release)
+	assert.Equal(t, "test-release", release.Metadata.Name)
+}


### PR DESCRIPTION
## Summary

Fixes #18 — `opm mod build`/`apply` unconditionally required `values.cue` on disk even when `--values` (`-f`) flags were provided.

## Changes

- **`internal/build/pipeline.go`** — Removed unconditional `values.cue` existence check from `resolveModulePath()`. Added conditional check in `Render()` that only requires `values.cue` when `len(opts.Values) == 0`.
- **`internal/build/release_builder.go`** — When `--values` flags are provided and `values.cue` exists on disk, overlay it with a minimal stub (`package <pkg>`) to prevent CUE unification conflicts between on-disk defaults and external values. Improved the "missing values" error message.
- **`internal/build/values_resolution_test.go`** — 10 new tests covering: `resolveModulePath` with/without `values.cue`, `Render()` conditional check, and `Build()` stub overlay behavior.
- **`internal/build/testdata/`** — Added 3 test fixtures: `test-module-no-values/`, `test-module-values-only/`, `external-values.cue`.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| No `values.cue`, no `--values` | Error | Error (improved message) |
| No `values.cue`, with `--values` | **Error** (bug) | Works |
| `values.cue` exists, no `--values` | Works | Works (unchanged) |
| `values.cue` exists, with `--values` | Potential conflict | Works (on-disk stubbed) |