### PR TITLE
chore: configure release-please for the v1 alpha prerelease line

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bump-minor-pre-major": true,
+  "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "include-component-in-tag": false,
   "include-v-in-tag": true,
@@ -9,6 +9,10 @@
       "release-type": "go",
       "package-name": "opm",
       "changelog-path": "CHANGELOG.md",
+      "versioning": "prerelease",
+      "prerelease": true,
+      "prerelease-type": "alpha",
+      "release-as": "1.0.0-alpha",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Adopt the v1 prerelease config the library, catalog_opm, and opm-operator repos use for the post-rename v1 rollout: disable bump-minor-pre-major and switch to prerelease versioning (prerelease-type: alpha).

Unlike opm-operator (whose merged breaking rename drove the major bump), the cli has no breaking-change commit since v0.6.0, so the config alone would only produce 0.7.0-alpha. release-as: 1.0.0-alpha forces the first release onto the v1.0.0-alpha line; it should be removed after that release so subsequent cuts compute normally (1.0.0-alpha.1, ...).