### PR TITLE
docs(openspec): draft cli-cr-inventory-backend change (0006 C1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Build artifacts
 bin/
 dist/
+!internal/operator/dist/
+!internal/operator/dist/install.yaml
 *.exe
 *.test
 *.out

--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ Use `opm instance` when you are starting from an instance file or when you want 
 | `config init` | Initialize OPM configuration |
 | `config vet` | Validate configuration |
 
+### Operator Lifecycle (`opm operator`)
+
+Use `opm operator` to put the opm-operator (and its CRDs) onto a cluster — a prerequisite for any `opm instance apply`.
+
+| Command | Description |
+|---------|-------------|
+| `operator install` | Install the opm-operator (`--crds-only`, `--rbac [--user\|--group]`, `--version`, `--timeout`) |
+| `operator uninstall` | Remove the opm-operator, preserving CRDs and its Namespace (`--remove-finalizers`) |
+
+```bash
+# Install the full operator and wait for it to become ready
+opm operator install
+
+# CLI-solo path: install just the CRDs, no running operator
+opm operator install --crds-only
+
+# Grant a non-admin user access to ModuleInstances
+opm operator install --crds-only --rbac --user alice
+
+# Remove the operator (refuses while any ModuleInstance is still active)
+opm operator uninstall
+```
+
 ## Example Instance Workflow
 
 ```bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -213,3 +213,26 @@ tasks:
     desc: Run go generate
     cmds:
       - go generate ./...
+
+  #########################
+  ## Operator lifecycle tasks
+  #########################
+  operator:sync:
+    desc: Refresh the embedded opm-operator manifest and version pin
+    summary: |
+      Downloads dist/install.yaml from the given opm-operator GitHub release tag,
+      replaces the embedded copy, and rewrites PinnedOperatorVersion to match.
+      The whole upgrade is one reviewable diff.
+
+      Usage:
+        task operator:sync VERSION=v1.0.0-alpha.3
+    vars:
+      VERSION: '{{.VERSION | default ""}}'
+    preconditions:
+      - sh: '[ -n "{{.VERSION}}" ]'
+        msg: "VERSION variable is required. Usage: task operator:sync VERSION=<tag>"
+    cmds:
+      - curl -sfL "https://github.com/open-platform-model/opm-operator/releases/download/{{.VERSION}}/install.yaml" -o internal/operator/dist/install.yaml
+      - perl -pi -e 's/^const PinnedOperatorVersion = ".*"/const PinnedOperatorVersion = "{{.VERSION}}"/' internal/operator/manifest.go
+      - gofmt -w internal/operator/manifest.go
+      - echo "Synced embedded operator manifest to {{.VERSION}}"

--- a/examples/cue.mod/module.cue
+++ b/examples/cue.mod/module.cue
@@ -16,12 +16,12 @@ deps: {
 		v: "v0.0.4"
 	}
 	"opmodel.dev/modules/jellyfin@v1": {
-		v: "v1.0.31"
+		v: "v1.0.32"
 	}
 	"opmodel.dev/modules/mc_java_fleet@v0": {
-		v: "v0.1.3"
+		v: "v0.2.0"
 	}
 	"opmodel.dev/opm/v1alpha1@v1": {
-		v: "v1.5.9"
+		v: "v1.6.0"
 	}
 }

--- a/internal/cmd/operator/install.go
+++ b/internal/cmd/operator/install.go
@@ -1,0 +1,138 @@
+package operatorcmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-platform-model/cli/internal/cmdutil"
+	"github.com/open-platform-model/cli/internal/config"
+	opmexit "github.com/open-platform-model/cli/internal/exit"
+	oplib "github.com/open-platform-model/cli/internal/operator"
+	"github.com/open-platform-model/cli/internal/output"
+)
+
+const defaultOperatorInstallTimeout = 5 * time.Minute
+
+// NewOperatorInstallCmd creates the operator install command.
+func NewOperatorInstallCmd(cfg *config.GlobalConfig) *cobra.Command {
+	var kf cmdutil.K8sFlags
+
+	var (
+		crdsOnlyFlag bool
+		rbacFlag     bool
+		userFlag     string
+		groupFlag    string
+		versionFlag  string
+		timeoutFlag  time.Duration
+	)
+
+	c := &cobra.Command{
+		Use:   "install",
+		Short: "Install the opm-operator on a cluster",
+		Long: `Server-side-apply the opm-operator onto the current cluster and wait for it
+to become ready.
+
+By default this applies the full embedded manifest (CRDs, RBAC, Deployment,
+Service) and waits for the CRDs to reach Established and the operator
+Deployment to complete its rollout. --crds-only applies just the CRDs, for
+clusters where the CLI drives module lifecycle without a running operator.
+
+Examples:
+  # Install the full operator
+  opm operator install
+
+  # Install only the CRDs
+  opm operator install --crds-only
+
+  # Install only the CRDs, plus RBAC for a specific user
+  opm operator install --crds-only --rbac --user alice
+
+  # Install a specific opm-operator release instead of the embedded pin
+  opm operator install --version v1.0.0-alpha.3`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runOperatorInstall(cfg, &kf, installFlags{
+				crdsOnly: crdsOnlyFlag,
+				rbac:     rbacFlag,
+				user:     userFlag,
+				group:    groupFlag,
+				version:  versionFlag,
+				timeout:  timeoutFlag,
+			})
+		},
+	}
+
+	kf.AddTo(c)
+	c.Flags().BoolVar(&crdsOnlyFlag, "crds-only", false, "Install only the CustomResourceDefinitions")
+	c.Flags().BoolVar(&rbacFlag, "rbac", false, "Also create the opm-cli-user ClusterRole")
+	c.Flags().StringVar(&userFlag, "user", "", "Bind the opm-cli-user ClusterRole to this user (requires --rbac)")
+	c.Flags().StringVar(&groupFlag, "group", "", "Bind the opm-cli-user ClusterRole to this group (requires --rbac)")
+	c.Flags().StringVar(&versionFlag, "version", "", "Fetch this opm-operator release tag instead of the embedded pin")
+	c.Flags().DurationVar(&timeoutFlag, "timeout", defaultOperatorInstallTimeout, "How long to wait for the install to become ready")
+
+	return c
+}
+
+// installFlags holds the parsed operator install flags.
+type installFlags struct {
+	crdsOnly bool
+	rbac     bool
+	user     string
+	group    string
+	version  string
+	timeout  time.Duration
+}
+
+func runOperatorInstall(cfg *config.GlobalConfig, kf *cmdutil.K8sFlags, flags installFlags) error {
+	rbac := oplib.RBACOptions{Enabled: flags.rbac, User: flags.user, Group: flags.group}
+	if err := rbac.Validate(); err != nil {
+		return &opmexit.ExitError{Code: opmexit.ExitValidationError, Err: err}
+	}
+
+	ctx := context.Background()
+
+	k8sConfig, err := config.ResolveKubernetes(config.ResolveKubernetesOptions{
+		Config:         cfg,
+		KubeconfigFlag: kf.Kubeconfig,
+		ContextFlag:    kf.Context,
+	})
+	if err != nil {
+		return &opmexit.ExitError{Code: opmexit.ExitGeneralError, Err: fmt.Errorf("resolving kubernetes config: %w", err)}
+	}
+	cmdutil.LogResolvedKubernetesConfig("", k8sConfig.Kubeconfig.Value, k8sConfig.Context.Value)
+
+	k8sClient, err := cmdutil.NewK8sClient(k8sConfig, cfg.Log.Kubernetes.APIWarnings)
+	if err != nil {
+		return err
+	}
+
+	output.Info(fmt.Sprintf("installing opm-operator%s", crdsOnlySuffix(flags.crdsOnly)))
+
+	result, err := oplib.Install(ctx, k8sClient, oplib.InstallOptions{
+		CRDsOnly: flags.crdsOnly,
+		Version:  flags.version,
+		Timeout:  flags.timeout,
+		RBAC:     rbac,
+	})
+	if err != nil {
+		if result != nil && result.Applied > 0 {
+			err = fmt.Errorf("%w (%d resource(s) applied for %s before this failure — install is idempotent, safe to re-run)", err, result.Applied, result.Version)
+		}
+		return &opmexit.ExitError{Code: cmdutil.ExitCodeFromK8sError(err), Err: err, Printed: false}
+	}
+
+	output.Println(output.FormatCheckmark(fmt.Sprintf(
+		"opm-operator %s installed (%s, %d resource(s) applied)", result.Version, result.Source, result.Applied,
+	)))
+	return nil
+}
+
+func crdsOnlySuffix(crdsOnly bool) string {
+	if crdsOnly {
+		return " (CRDs only)"
+	}
+	return ""
+}

--- a/internal/cmd/operator/operator.go
+++ b/internal/cmd/operator/operator.go
@@ -1,0 +1,27 @@
+// Package operatorcmd provides CLI command implementations for the operator
+// command group.
+package operatorcmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-platform-model/cli/internal/config"
+)
+
+// NewOperatorCmd creates the operator command group.
+func NewOperatorCmd(cfg *config.GlobalConfig) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "operator",
+		Short: "Install and manage the opm-operator on a cluster",
+		Long: `Install, upgrade, and remove the opm-operator on a Kubernetes cluster.
+
+opm operator prepares a cluster for OPM workflows that depend on the operator:
+its CRDs (ModuleInstance, ModulePackage, Platform) and, for full deployments,
+the running controller itself.`,
+	}
+
+	c.AddCommand(NewOperatorInstallCmd(cfg))
+	c.AddCommand(NewOperatorUninstallCmd(cfg))
+
+	return c
+}

--- a/internal/cmd/operator/operator_test.go
+++ b/internal/cmd/operator/operator_test.go
@@ -1,0 +1,44 @@
+package operatorcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-platform-model/cli/internal/config"
+)
+
+func TestNewOperatorCmd(t *testing.T) {
+	cmd := NewOperatorCmd(&config.GlobalConfig{})
+
+	assert.Equal(t, "operator", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, c := range cmd.Commands() {
+		names = append(names, c.Name())
+	}
+	assert.ElementsMatch(t, []string{"install", "uninstall"}, names)
+}
+
+func TestNewOperatorInstallCmd(t *testing.T) {
+	cmd := NewOperatorInstallCmd(&config.GlobalConfig{})
+
+	assert.Equal(t, "install", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+
+	for _, flag := range []string{"crds-only", "rbac", "user", "group", "version", "timeout", "kubeconfig", "context"} {
+		assert.NotNil(t, cmd.Flags().Lookup(flag), "expected --%s flag", flag)
+	}
+}
+
+func TestNewOperatorUninstallCmd(t *testing.T) {
+	cmd := NewOperatorUninstallCmd(&config.GlobalConfig{})
+
+	assert.Equal(t, "uninstall", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+
+	for _, flag := range []string{"remove-finalizers", "kubeconfig", "context"} {
+		assert.NotNil(t, cmd.Flags().Lookup(flag), "expected --%s flag", flag)
+	}
+}

--- a/internal/cmd/operator/uninstall.go
+++ b/internal/cmd/operator/uninstall.go
@@ -1,0 +1,98 @@
+package operatorcmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-platform-model/cli/internal/cmdutil"
+	"github.com/open-platform-model/cli/internal/config"
+	opmexit "github.com/open-platform-model/cli/internal/exit"
+	oplib "github.com/open-platform-model/cli/internal/operator"
+	"github.com/open-platform-model/cli/internal/output"
+)
+
+// NewOperatorUninstallCmd creates the operator uninstall command.
+func NewOperatorUninstallCmd(cfg *config.GlobalConfig) *cobra.Command {
+	var kf cmdutil.K8sFlags
+	var removeFinalizersFlag bool
+
+	c := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove the opm-operator from a cluster",
+		Long: `Delete everything 'opm operator install' applied, except the CRDs and the
+operator's Namespace — those remain for a deliberate, separate 'kubectl delete
+crd' once you're sure no ModuleInstance data is still needed.
+
+Refuses to proceed while any ModuleInstance still carries the operator's
+cleanup finalizer: deleting the operator out from under it would orphan its
+workload without the operator ever running cleanup. --remove-finalizers
+overrides this by stripping just that finalizer (leaving any other
+finalizers intact) and proceeding — the instance's resources become
+unmanaged.
+
+Examples:
+  # Remove the operator (refuses if any ModuleInstance is still active)
+  opm operator uninstall
+
+  # Remove the operator, orphaning any still-active ModuleInstances
+  opm operator uninstall --remove-finalizers`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runOperatorUninstall(cfg, &kf, removeFinalizersFlag)
+		},
+	}
+
+	kf.AddTo(c)
+	c.Flags().BoolVar(&removeFinalizersFlag, "remove-finalizers", false,
+		"Strip the operator's cleanup finalizer from active ModuleInstances and proceed")
+
+	return c
+}
+
+func runOperatorUninstall(cfg *config.GlobalConfig, kf *cmdutil.K8sFlags, removeFinalizers bool) error {
+	ctx := context.Background()
+
+	k8sConfig, err := config.ResolveKubernetes(config.ResolveKubernetesOptions{
+		Config:         cfg,
+		KubeconfigFlag: kf.Kubeconfig,
+		ContextFlag:    kf.Context,
+	})
+	if err != nil {
+		return &opmexit.ExitError{Code: opmexit.ExitGeneralError, Err: fmt.Errorf("resolving kubernetes config: %w", err)}
+	}
+	cmdutil.LogResolvedKubernetesConfig("", k8sConfig.Kubeconfig.Value, k8sConfig.Context.Value)
+
+	k8sClient, err := cmdutil.NewK8sClient(k8sConfig, cfg.Log.Kubernetes.APIWarnings)
+	if err != nil {
+		return err
+	}
+
+	output.Info("uninstalling opm-operator")
+
+	result, err := oplib.Uninstall(ctx, k8sClient, oplib.UninstallOptions{RemoveFinalizers: removeFinalizers})
+	if err != nil {
+		var guardErr *oplib.FinalizerGuardError
+		if errors.As(err, &guardErr) {
+			return &opmexit.ExitError{Code: opmexit.ExitValidationError, Err: err}
+		}
+		return &opmexit.ExitError{Code: cmdutil.ExitCodeFromK8sError(err), Err: err}
+	}
+
+	if len(result.Errors) > 0 {
+		output.Warn(fmt.Sprintf("%d resource(s) had errors", len(result.Errors)))
+		for _, e := range result.Errors {
+			output.Error(e.Error())
+		}
+		return &opmexit.ExitError{
+			Code:    opmexit.ExitGeneralError,
+			Err:     fmt.Errorf("%d resource(s) failed to delete", len(result.Errors)),
+			Printed: true,
+		}
+	}
+
+	output.Println(output.FormatCheckmark(fmt.Sprintf("opm-operator uninstalled (%d resource(s) deleted)", result.Deleted)))
+	return nil
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	cmdconfig "github.com/open-platform-model/cli/internal/cmd/config"
 	cmdinstance "github.com/open-platform-model/cli/internal/cmd/instance" // Was: cmdrelease "…/internal/cmd/release" (enhancement 0002 D6)
 	cmdmodule "github.com/open-platform-model/cli/internal/cmd/module"
+	cmdoperator "github.com/open-platform-model/cli/internal/cmd/operator"
 	"github.com/open-platform-model/cli/internal/cmdutil"
 	"github.com/open-platform-model/cli/internal/config"
 	"github.com/open-platform-model/cli/internal/output"
@@ -52,6 +53,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(cmdmodule.NewModuleCmd(&cfg))
 	rootCmd.AddCommand(cmdconfig.NewConfigCmd(&cfg))
 	rootCmd.AddCommand(cmdinstance.NewInstanceCmd(&cfg))
+	rootCmd.AddCommand(cmdoperator.NewOperatorCmd(&cfg))
 
 	return rootCmd
 }

--- a/internal/kubernetes/apply.go
+++ b/internal/kubernetes/apply.go
@@ -67,7 +67,7 @@ func Apply(ctx context.Context, client *Client, resources []*unstructured.Unstru
 		ns := res.GetNamespace()
 
 		// Apply the resource
-		status, err := applyResource(ctx, client, res, opts)
+		status, err := ApplyOne(ctx, client, res, opts)
 		if err != nil {
 			instanceLog.Warn(fmt.Sprintf("applying %s/%s: %v", kind, name, err))
 			result.Errors = append(result.Errors, resourceError{
@@ -94,10 +94,10 @@ func Apply(ctx context.Context, client *Client, resources []*unstructured.Unstru
 	return result, nil
 }
 
-// applyResource performs server-side apply for a single resource.
+// ApplyOne performs server-side apply for a single resource.
 // Returns the status of the operation (created, configured, or unchanged).
-func applyResource(ctx context.Context, client *Client, obj *unstructured.Unstructured, opts ApplyOptions) (string, error) {
-	gvr := gvrFromUnstructured(obj)
+func ApplyOne(ctx context.Context, client *Client, obj *unstructured.Unstructured, opts ApplyOptions) (string, error) {
+	gvr := GVRFromUnstructured(obj)
 	ns := obj.GetNamespace()
 
 	// Check if resource already exists to determine status after apply.

--- a/internal/kubernetes/delete.go
+++ b/internal/kubernetes/delete.go
@@ -141,7 +141,7 @@ func Delete(ctx context.Context, client *Client, opts DeleteOptions) (*DeleteRes
 
 // deleteResource deletes a single resource with foreground propagation.
 func deleteResource(ctx context.Context, client *Client, obj *unstructured.Unstructured) error {
-	gvr := gvrFromUnstructured(obj)
+	gvr := GVRFromUnstructured(obj)
 	ns := obj.GetNamespace()
 	propagation := metav1.DeletePropagationForeground
 

--- a/internal/kubernetes/delete_test.go
+++ b/internal/kubernetes/delete_test.go
@@ -59,10 +59,10 @@ func TestDelete_DeletesOnlyTrackedInventoryResources(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, 1, result.Deleted)
 
-	_, err = client.ResourceClient(gvrFromUnstructured(tracked), namespace).Get(ctx, tracked.GetName(), metav1.GetOptions{})
+	_, err = client.ResourceClient(GVRFromUnstructured(tracked), namespace).Get(ctx, tracked.GetName(), metav1.GetOptions{})
 	assert.Error(t, err)
 
-	remaining, err := client.ResourceClient(gvrFromUnstructured(untracked), namespace).Get(ctx, untracked.GetName(), metav1.GetOptions{})
+	remaining, err := client.ResourceClient(GVRFromUnstructured(untracked), namespace).Get(ctx, untracked.GetName(), metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, untracked.GetName(), remaining.GetName())
 

--- a/internal/kubernetes/diff.go
+++ b/internal/kubernetes/diff.go
@@ -304,7 +304,7 @@ func buildNameIndex(live []interface{}) map[string]map[string]interface{} {
 
 // FetchLiveState fetches a single resource from the cluster.
 func fetchLiveState(ctx context.Context, client *Client, resource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	gvr := gvrFromUnstructured(resource)
+	gvr := GVRFromUnstructured(resource)
 	ns := resource.GetNamespace()
 	name := resource.GetName()
 

--- a/internal/kubernetes/labels.go
+++ b/internal/kubernetes/labels.go
@@ -1,4 +1,4 @@
 package kubernetes
 
 // fieldManagerName is the field manager used for server-side apply.
-const fieldManagerName = "opm"
+const fieldManagerName = "opm-cli"

--- a/internal/kubernetes/resource.go
+++ b/internal/kubernetes/resource.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-// gvrFromUnstructured derives GroupVersionResource from an unstructured object.
-func gvrFromUnstructured(obj *unstructured.Unstructured) schema.GroupVersionResource {
+// GVRFromUnstructured derives GroupVersionResource from an unstructured object.
+func GVRFromUnstructured(obj *unstructured.Unstructured) schema.GroupVersionResource {
 	gvk := obj.GroupVersionKind()
 	return schema.GroupVersionResource{
 		Group:    gvk.Group,

--- a/internal/kubernetes/resource_test.go
+++ b/internal/kubernetes/resource_test.go
@@ -59,23 +59,23 @@ func TestHeuristicPluralize(t *testing.T) {
 	}
 }
 
-func TestGvrFromUnstructured(t *testing.T) {
+func TestGVRFromUnstructured(t *testing.T) {
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion("apps/v1")
 	obj.SetKind("Deployment")
 
-	gvr := gvrFromUnstructured(obj)
+	gvr := GVRFromUnstructured(obj)
 	assert.Equal(t, "apps", gvr.Group)
 	assert.Equal(t, "v1", gvr.Version)
 	assert.Equal(t, "deployments", gvr.Resource)
 }
 
-func TestGvrFromUnstructured_CoreGroup(t *testing.T) {
+func TestGVRFromUnstructured_CoreGroup(t *testing.T) {
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion("v1")
 	obj.SetKind("Service")
 
-	gvr := gvrFromUnstructured(obj)
+	gvr := GVRFromUnstructured(obj)
 	assert.Equal(t, "", gvr.Group)
 	assert.Equal(t, "v1", gvr.Version)
 	assert.Equal(t, "services", gvr.Resource)

--- a/internal/operator/dist/install.yaml
+++ b/internal/operator/dist/install.yaml
@@ -1,0 +1,1248 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+    control-plane: controller-manager
+  name: opm-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: moduleinstances.opmodel.dev
+spec:
+  group: opmodel.dev
+  names:
+    kind: ModuleInstance
+    listKind: ModuleInstanceList
+    plural: moduleinstances
+    shortNames:
+    - mi
+    singular: moduleinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.module.path
+      name: Module
+      type: string
+    - jsonPath: .spec.module.version
+      name: Version
+      type: string
+    - jsonPath: .status.nextRetryAt
+      name: Retry
+      priority: 1
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ModuleInstance is the Schema for the moduleinstances API
+
+          Was: ModuleRelease
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of ModuleInstance
+            properties:
+              module:
+                description: Module identifies the CUE module to evaluate from the
+                  OCI registry.
+                properties:
+                  path:
+                    description: |-
+                      Path is the CUE module import path.
+                      Example: "opmodel.dev/modules/cert_manager@v0"
+                    minLength: 1
+                    type: string
+                  version:
+                    description: |-
+                      Version is the pinned module version to resolve from the registry.
+                      Example: "v0.2.1"
+                    minLength: 1
+                    type: string
+                required:
+                - path
+                - version
+                type: object
+              owner:
+                description: |-
+                  Owner identifies which actor manages this instance. An absent, empty, or
+                  "operator" value means operator-managed: the controller reconciles
+                  normally. Only an explicit "cli" makes the operator skip the instance
+                  (no render/apply/prune, no finalizer) and record a single
+                  ManagedExternally acknowledgement. There is no CRD default; the
+                  reconciler carries the operator-managed default semantics.
+                enum:
+                - cli
+                - operator
+                type: string
+              prune:
+                type: boolean
+              rollout:
+                description: RolloutSpec configures apply behavior for a release.
+                properties:
+                  forceConflicts:
+                    description: ForceConflicts enables SSA force ownership when desired.
+                    type: boolean
+                  strategy:
+                    description: Strategy controls how apply operations are performed.
+                    enum:
+                    - Apply
+                    type: string
+                type: object
+              serviceAccountName:
+                type: string
+              suspend:
+                type: boolean
+              values:
+                description: Values contains arbitrary release input values.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - module
+            type: object
+          status:
+            description: status defines the observed state of ModuleInstance
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the ModuleInstance resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              failureCounters:
+                description: FailureCounters tracks bounded reconcile failure counts
+                  by action.
+                properties:
+                  apply:
+                    format: int64
+                    type: integer
+                  drift:
+                    format: int64
+                    type: integer
+                  prune:
+                    format: int64
+                    type: integer
+                  reconcile:
+                    format: int64
+                    type: integer
+                type: object
+              history:
+                items:
+                  description: HistoryEntry captures a compact reconcile history record.
+                  properties:
+                    action:
+                      type: string
+                    configDigest:
+                      type: string
+                    finishedAt:
+                      format: date-time
+                      type: string
+                    inventoryCount:
+                      format: int64
+                      type: integer
+                    inventoryDigest:
+                      type: string
+                    message:
+                      type: string
+                    phase:
+                      type: string
+                    renderDigest:
+                      type: string
+                    sequence:
+                      format: int64
+                      type: integer
+                    sourceDigest:
+                      type: string
+                    startedAt:
+                      format: date-time
+                      type: string
+                  type: object
+                type: array
+              instanceUUID:
+                description: |-
+                  InstanceUUID is the globally-unique identity of the rendered ModuleInstance,
+                  read from the `module-instance.opmodel.dev/uuid` label on rendered resources.
+                  Populated on the first successful render; consumed by the prune ownership
+                  guard (including the deletion path where a fresh render is not available).
+                type: string
+              inventory:
+                description: Inventory stores the current set of owned resources.
+                properties:
+                  count:
+                    format: int64
+                    type: integer
+                  digest:
+                    type: string
+                  entries:
+                    items:
+                      description: InventoryEntry identifies one owned Kubernetes
+                        resource.
+                      properties:
+                        component:
+                          type: string
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        v:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  revision:
+                    format: int64
+                    type: integer
+                type: object
+              lastAppliedAt:
+                format: date-time
+                type: string
+              lastAppliedConfigDigest:
+                type: string
+              lastAppliedRenderDigest:
+                type: string
+              lastAppliedSourceDigest:
+                type: string
+              lastAttemptedAction:
+                type: string
+              lastAttemptedAt:
+                format: date-time
+                type: string
+              lastAttemptedConfigDigest:
+                type: string
+              lastAttemptedDuration:
+                type: string
+              lastAttemptedRenderDigest:
+                type: string
+              lastAttemptedSourceDigest:
+                type: string
+              nextRetryAt:
+                description: |-
+                  NextRetryAt indicates when the controller will next attempt reconciliation
+                  after a transient or stalled failure. Nil when the resource is healthy or no-op.
+                format: date-time
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: modulepackages.opmodel.dev
+spec:
+  group: opmodel.dev
+  names:
+    kind: ModulePackage
+    listKind: ModulePackageList
+    plural: modulepackages
+    shortNames:
+    - mpkg
+    singular: modulepackage
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source
+      type: string
+    - jsonPath: .spec.path
+      name: Path
+      type: string
+    - jsonPath: .status.source.artifactRevision
+      name: Revision
+      priority: 1
+      type: string
+    - jsonPath: .status.nextRetryAt
+      name: Retry
+      priority: 1
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Was: Release
+          ModulePackage is the Schema for the modulepackages API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of ModulePackage
+            properties:
+              dependsOn:
+                description: |-
+                  DependsOn references other ModulePackage CRs that must be Ready=True before
+                  this ModulePackage is reconciled. References are same-namespace only.
+                items:
+                  description: |-
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              interval:
+                description: |-
+                  Interval at which the reconciler re-evaluates the package to detect drift
+                  and re-apply. Also the requeue interval after transient failures.
+                type: string
+              path:
+                description: |-
+                  Path is the directory within the artifact containing instance.cue.
+                  Example: "releases/prod/minecraft".
+                minLength: 1
+                type: string
+              prune:
+                description: |-
+                  Prune enables deletion of stale resources on reconcile and of all owned
+                  resources on ModulePackage deletion.
+                type: boolean
+              rollout:
+                description: Rollout configures apply behavior.
+                properties:
+                  forceConflicts:
+                    description: ForceConflicts enables SSA force ownership when desired.
+                    type: boolean
+                  strategy:
+                    description: Strategy controls how apply operations are performed.
+                    enum:
+                    - Apply
+                    type: string
+                type: object
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the ServiceAccount used to impersonate
+                  during apply and prune. Empty means use the controller's identity.
+                type: string
+              sourceRef:
+                description: |-
+                  SourceRef references a Flux source (OCIRepository, GitRepository, or Bucket)
+                  that provides the artifact containing the CUE package.
+                properties:
+                  apiVersion:
+                    description: API version of the referent, if not specified the
+                      Kubernetes preferred version will be used.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                  namespace:
+                    description: Namespace of the referent, when not specified it
+                      acts as LocalObjectReference.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: Suspend halts reconciliation when true.
+                type: boolean
+            required:
+            - path
+            - sourceRef
+            type: object
+          status:
+            description: status defines the observed state of ModulePackage
+            properties:
+              conditions:
+                description: conditions represent the current state of the ModulePackage
+                  resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              failureCounters:
+                description: FailureCounters tracks bounded reconcile failure counts
+                  by action.
+                properties:
+                  apply:
+                    format: int64
+                    type: integer
+                  drift:
+                    format: int64
+                    type: integer
+                  prune:
+                    format: int64
+                    type: integer
+                  reconcile:
+                    format: int64
+                    type: integer
+                type: object
+              history:
+                items:
+                  description: HistoryEntry captures a compact reconcile history record.
+                  properties:
+                    action:
+                      type: string
+                    configDigest:
+                      type: string
+                    finishedAt:
+                      format: date-time
+                      type: string
+                    inventoryCount:
+                      format: int64
+                      type: integer
+                    inventoryDigest:
+                      type: string
+                    message:
+                      type: string
+                    phase:
+                      type: string
+                    renderDigest:
+                      type: string
+                    sequence:
+                      format: int64
+                      type: integer
+                    sourceDigest:
+                      type: string
+                    startedAt:
+                      format: date-time
+                      type: string
+                  type: object
+                type: array
+              inventory:
+                description: Inventory stores the current set of owned resources.
+                properties:
+                  count:
+                    format: int64
+                    type: integer
+                  digest:
+                    type: string
+                  entries:
+                    items:
+                      description: InventoryEntry identifies one owned Kubernetes
+                        resource.
+                      properties:
+                        component:
+                          type: string
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        v:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  revision:
+                    format: int64
+                    type: integer
+                type: object
+              lastAppliedAt:
+                format: date-time
+                type: string
+              lastAppliedConfigDigest:
+                type: string
+              lastAppliedRenderDigest:
+                type: string
+              lastAppliedSourceDigest:
+                type: string
+              lastAttemptedAction:
+                type: string
+              lastAttemptedAt:
+                format: date-time
+                type: string
+              lastAttemptedConfigDigest:
+                type: string
+              lastAttemptedDuration:
+                type: string
+              lastAttemptedRenderDigest:
+                type: string
+              lastAttemptedSourceDigest:
+                type: string
+              nextRetryAt:
+                description: |-
+                  NextRetryAt indicates when the controller will next attempt reconciliation
+                  after a transient or stalled failure.
+                format: date-time
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              source:
+                description: Source is the resolved Flux source artifact metadata.
+                properties:
+                  artifactDigest:
+                    description: ArtifactDigest is the digest reported by the source
+                      artifact.
+                    type: string
+                  artifactRevision:
+                    description: ArtifactRevision is the revision reported by the
+                      source artifact.
+                    type: string
+                  artifactURL:
+                    description: ArtifactURL is the fetch URL reported by the source
+                      artifact.
+                    type: string
+                  ref:
+                    description: Ref is the resolved source reference.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent, if not specified
+                          the Kubernetes preferred version will be used.
+                        type: string
+                      kind:
+                        description: Kind of the referent.
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                      namespace:
+                        description: Namespace of the referent, when not specified
+                          it acts as LocalObjectReference.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: platforms.opmodel.dev
+spec:
+  group: opmodel.dev
+  names:
+    kind: Platform
+    listKind: PlatformList
+    plural: platforms
+    shortNames:
+    - plat
+    singular: platform
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Platform is the Schema for the platforms API. It is a cluster-scoped
+          singleton (the only permitted name is "cluster") whose spec projects the
+          core #Platform author surface.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Platform
+            properties:
+              registry:
+                additionalProperties:
+                  description: |-
+                    Subscription is a single catalog registry subscription, projecting core
+                    #Subscription. It maps onto synth.SubscriptionSpec.
+                  properties:
+                    enable:
+                      description: |-
+                        Enable toggles the subscription. A pointer so that an omitted value
+                        defers to the schema default (true) rather than serializing as an
+                        explicit false; matches synth.SubscriptionSpec.Enable.
+                      type: boolean
+                    filter:
+                      description: |-
+                        Filter optionally constrains the subscribed versions by SemVer range
+                        and explicit allow/deny lists.
+                      properties:
+                        allow:
+                          description: Allow is an explicit allowlist of versions.
+                          items:
+                            type: string
+                          type: array
+                        deny:
+                          description: Deny is an explicit denylist of versions.
+                          items:
+                            type: string
+                          type: array
+                        range:
+                          description: Range is a SemVer constraint (e.g. ">=1.2.0
+                            <2.0.0").
+                          type: string
+                      type: object
+                  type: object
+                description: |-
+                  Registry is the set of catalog subscriptions keyed by catalog CUE module
+                  path (e.g. "opmodel.dev/catalogs/opm"), projecting core #Platform.#registry.
+                type: object
+              type:
+                description: |-
+                  Type is the informational discriminator for the platform (core
+                  #Platform.type). It does not affect matching; it labels the platform
+                  flavor for operators and downstream tooling.
+                minLength: 1
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: status defines the observed state of Platform
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the Platform resource. The
+                  PlatformReconciler summarizes materialization on the Ready condition:
+                  Ready=True (reason Materialized) on success, Ready=False (reason
+                  MaterializeFailed) on a MaterializeError.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: Platform is a cluster singleton; the only permitted name is 'cluster'
+          rule: self.metadata.name == 'cluster'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+  name: opm-operator-controller-manager
+  namespace: opm-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+  name: opm-operator-leader-election-role
+  namespace: opm-operator-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opm-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - groups
+  - users
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - impersonate
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances
+  - modulepackages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances/finalizers
+  - modulepackages/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances/status
+  - modulepackages/status
+  - platforms/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - platforms
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - buckets
+  - gitrepositories
+  - ocirepositories
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opm-operator-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opm-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+  name: opm-operator-moduleinstance-admin-role
+rules:
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances
+  verbs:
+  - '*'
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+  name: opm-operator-moduleinstance-editor-role
+rules:
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+  name: opm-operator-moduleinstance-viewer-role
+rules:
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - opmodel.dev
+  resources:
+  - moduleinstances/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+  name: opm-operator-leader-election-rolebinding
+  namespace: opm-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: opm-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: opm-operator-controller-manager
+  namespace: opm-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+  name: opm-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opm-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: opm-operator-controller-manager
+  namespace: opm-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: opm-operator-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opm-operator-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: opm-operator-controller-manager
+  namespace: opm-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+    control-plane: controller-manager
+  name: opm-operator-controller-manager-metrics-service
+  namespace: opm-operator-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: opm-operator
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: opm-operator
+    control-plane: controller-manager
+  name: opm-operator-controller-manager
+  namespace: opm-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opm-operator
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: opm-operator
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        image: ghcr.io/open-platform-model/opm-operator:v1.0.0-alpha.2@sha256:9ee84e3ec4ef160a90bd1c89a32b765d4e89d7aa846763faee243092dbc9c2d8
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports: []
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: opm-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: tmp

--- a/internal/operator/fetch.go
+++ b/internal/operator/fetch.go
@@ -1,0 +1,49 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// operatorReleaseBaseURL is the GitHub releases download base for opm-operator.
+// Release assets live at <base>/<tag>/install.yaml.
+const operatorReleaseBaseURL = "https://github.com/open-platform-model/opm-operator/releases/download"
+
+// fetchTimeout bounds how long a --version fetch may take.
+const fetchTimeout = 30 * time.Second
+
+// fetchManifest downloads install.yaml from the opm-operator GitHub release
+// for the given tag over HTTPS, bounded by fetchTimeout. No checksum or
+// signature verification is performed (0006/D35). baseURL is injectable so
+// tests can point it at a stub server instead of GitHub.
+func fetchManifest(ctx context.Context, baseURL, tag string) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/install.yaml", baseURL, tag)
+
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("building request for opm-operator %s: %w", tag, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching opm-operator %s from %s: %w", tag, url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching opm-operator %s: server returned %s for %s", tag, resp.Status, url)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading opm-operator %s manifest from %s: %w", tag, url, err)
+	}
+
+	return data, nil
+}

--- a/internal/operator/fetch_test.go
+++ b/internal/operator/fetch_test.go
@@ -1,0 +1,56 @@
+package operator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchManifest_BuildsExpectedURL(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("apiVersion: v1\nkind: Namespace\n"))
+	}))
+	defer server.Close()
+
+	data, err := fetchManifest(context.Background(), server.URL, "v1.0.0-alpha.3")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v1.0.0-alpha.3/install.yaml", gotPath)
+	assert.Contains(t, string(data), "kind: Namespace")
+}
+
+func TestFetchManifest_MissingTagErrorsNamingTagAndURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := fetchManifest(context.Background(), server.URL, "v9.9.9")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "v9.9.9")
+	assert.ErrorContains(t, err, server.URL+"/v9.9.9/install.yaml")
+}
+
+func TestFetchManifest_ServerErrorSurfacesStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := fetchManifest(context.Background(), server.URL, "v1.0.0-alpha.2")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "500")
+}
+
+func TestFetchManifest_UnreachableHostErrors(t *testing.T) {
+	_, err := fetchManifest(context.Background(), "https://127.0.0.1:1", "v1.0.0-alpha.2")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "v1.0.0-alpha.2")
+}

--- a/internal/operator/install.go
+++ b/internal/operator/install.go
@@ -1,0 +1,103 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/open-platform-model/cli/internal/kubernetes"
+	"github.com/open-platform-model/cli/internal/output"
+)
+
+// InstallOptions configures an install run.
+type InstallOptions struct {
+	// CRDsOnly applies only the CustomResourceDefinition documents and waits
+	// only for their Established condition.
+	CRDsOnly bool
+
+	// Version, when non-empty, fetches install.yaml from that opm-operator
+	// release tag instead of using the embedded artifact.
+	Version string
+
+	// Timeout bounds the readiness wait.
+	Timeout time.Duration
+
+	// RBAC configures optional opm-cli-user ClusterRole/ClusterRoleBinding
+	// emission, appended to the plan regardless of CRDsOnly.
+	RBAC RBACOptions
+}
+
+// InstallResult reports the outcome of an install run.
+type InstallResult struct {
+	// Version is the opm-operator version that was installed: the embedded
+	// pin, or the fetched --version tag.
+	Version string
+
+	// Source is "embedded" or "fetched".
+	Source string
+
+	// Applied is the number of resources server-side-applied.
+	Applied int
+}
+
+// Install server-side-applies the operator manifest (or just its CRD subset)
+// with field manager opm-cli, then waits, bounded by opts.Timeout, for the
+// applied resources to become ready. Apply stops at the first resource error —
+// a partially applied operator install is not a state worth waiting on.
+func Install(ctx context.Context, client *kubernetes.Client, opts InstallOptions) (*InstallResult, error) {
+	manifest, version, source, err := resolveManifest(ctx, opts.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	plan := InstallPlan(manifest)
+	if opts.CRDsOnly {
+		plan = CRDsOnlyPlan(manifest)
+	}
+	if rbacObjs := opts.RBAC.Objects(); len(rbacObjs) > 0 {
+		plan = append(plan, rbacObjs...)
+		sortByWeightAscending(plan)
+	}
+
+	result := &InstallResult{Version: version, Source: source}
+
+	for _, obj := range plan {
+		status, err := kubernetes.ApplyOne(ctx, client, obj, kubernetes.ApplyOptions{})
+		if err != nil {
+			return result, fmt.Errorf("applying %s/%s: %w", obj.GetKind(), obj.GetName(), err)
+		}
+		result.Applied++
+		output.Info(output.FormatResourceLine(obj.GetKind(), obj.GetNamespace(), obj.GetName(), status))
+	}
+
+	if err := Wait(ctx, client, plan, DefaultPredicate, opts.Timeout); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+// resolveManifest returns the manifest to install: the embedded, pinned
+// artifact by default, or a fetched one when version is non-empty.
+func resolveManifest(ctx context.Context, version string) (objs []*unstructured.Unstructured, resolvedVersion, source string, err error) {
+	return resolveManifestFrom(ctx, operatorReleaseBaseURL, version)
+}
+
+// resolveManifestFrom is the testable core of resolveManifest — baseURL is
+// injectable so tests can point a --version fetch at a stub server.
+func resolveManifestFrom(ctx context.Context, baseURL, version string) (objs []*unstructured.Unstructured, resolvedVersion, source string, err error) {
+	if version == "" {
+		objs, err := EmbeddedManifest()
+		return objs, PinnedOperatorVersion, "embedded", err
+	}
+
+	data, err := fetchManifest(ctx, baseURL, version)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	objs, err = ParseManifest(data)
+	return objs, version, "fetched", err
+}

--- a/internal/operator/install_test.go
+++ b/internal/operator/install_test.go
@@ -1,0 +1,58 @@
+package operator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveManifest_EmptyVersionUsesEmbedded(t *testing.T) {
+	objs, version, source, err := resolveManifest(context.Background(), "")
+	require.NoError(t, err)
+
+	assert.Equal(t, PinnedOperatorVersion, version)
+	assert.Equal(t, "embedded", source)
+	assert.Len(t, objs, 17)
+}
+
+func TestResolveManifest_VersionFetchesInstead(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: fetched-ns\n"))
+	}))
+	defer server.Close()
+
+	objs, version, source, err := resolveManifestFrom(context.Background(), server.URL, "v1.0.0-alpha.3")
+	require.NoError(t, err)
+
+	assert.Equal(t, "v1.0.0-alpha.3", version)
+	assert.Equal(t, "fetched", source)
+	require.Len(t, objs, 1)
+	assert.Equal(t, "fetched-ns", objs[0].GetName())
+}
+
+func TestResolveManifest_FetchErrorPropagates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	objs, version, source, err := resolveManifestFrom(context.Background(), server.URL, "v9.9.9")
+	require.Error(t, err)
+	assert.Empty(t, objs)
+	assert.Empty(t, version)
+	assert.Empty(t, source)
+	assert.ErrorContains(t, err, "v9.9.9")
+}
+
+// Install's apply+wait wiring (--crds-only, --version, --timeout) is
+// exercised end-to-end against a real kind cluster in the e2e suite (task
+// 6.1) rather than here: the fake dynamic client's Apply reactor doesn't
+// support server-side-apply patches against unstructured.Unstructured
+// objects (it falls back to reflection-based strategic-merge-patch, which
+// only works for typed structs), so it can't stand in for a real apiserver
+// on this code path.

--- a/internal/operator/manifest.go
+++ b/internal/operator/manifest.go
@@ -1,0 +1,50 @@
+// Package operator implements the opm-operator lifecycle surface: embedding
+// the pinned operator manifest, deriving install/uninstall plans from it,
+// applying and waiting for readiness, and the uninstall safety checks.
+package operator
+
+import (
+	"bytes"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// PinnedOperatorVersion is the opm-operator release tag whose dist/install.yaml
+// is embedded below. Refresh both together with `task operator:sync VERSION=<tag>`.
+const PinnedOperatorVersion = "v1.0.0-alpha.2"
+
+//go:embed dist/install.yaml
+var embeddedManifest []byte
+
+// ParseManifest decodes a multi-document YAML manifest into unstructured objects.
+func ParseManifest(data []byte) ([]*unstructured.Unstructured, error) {
+	decoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+
+	var objs []*unstructured.Unstructured
+	for {
+		var raw map[string]any
+		if err := decoder.Decode(&raw); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("decoding manifest document: %w", err)
+		}
+		if len(raw) == 0 {
+			continue
+		}
+		objs = append(objs, &unstructured.Unstructured{Object: raw})
+	}
+
+	return objs, nil
+}
+
+// EmbeddedManifest parses and returns the objects from the embedded, pinned
+// operator manifest.
+func EmbeddedManifest() ([]*unstructured.Unstructured, error) {
+	return ParseManifest(embeddedManifest)
+}

--- a/internal/operator/manifest_test.go
+++ b/internal/operator/manifest_test.go
@@ -1,0 +1,62 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedManifest_ParsesAllDocuments(t *testing.T) {
+	objs, err := EmbeddedManifest()
+	require.NoError(t, err)
+
+	// The pinned dist/install.yaml: 1 Namespace, 3 CRDs, RBAC set, Service, Deployment.
+	assert.Len(t, objs, 17)
+
+	kindCounts := map[string]int{}
+	for _, obj := range objs {
+		kindCounts[obj.GetKind()]++
+	}
+
+	assert.Equal(t, 1, kindCounts["Namespace"])
+	assert.Equal(t, 3, kindCounts["CustomResourceDefinition"])
+	assert.Equal(t, 1, kindCounts["ServiceAccount"])
+	assert.Equal(t, 1, kindCounts["Service"])
+	assert.Equal(t, 1, kindCounts["Deployment"])
+	assert.Positive(t, kindCounts["ClusterRole"])
+	assert.Positive(t, kindCounts["ClusterRoleBinding"])
+}
+
+func TestEmbeddedManifest_CRDNamesAreExpected(t *testing.T) {
+	objs, err := EmbeddedManifest()
+	require.NoError(t, err)
+
+	var crdNames []string
+	for _, obj := range objs {
+		if obj.GetKind() == "CustomResourceDefinition" {
+			crdNames = append(crdNames, obj.GetName())
+		}
+	}
+
+	assert.ElementsMatch(t, []string{
+		"moduleinstances.opmodel.dev",
+		"modulepackages.opmodel.dev",
+		"platforms.opmodel.dev",
+	}, crdNames)
+}
+
+func TestParseManifest_EmptyDocumentsAreSkipped(t *testing.T) {
+	data := []byte("---\n---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: foo\n---\n")
+
+	objs, err := ParseManifest(data)
+	require.NoError(t, err)
+	require.Len(t, objs, 1)
+	assert.Equal(t, "Namespace", objs[0].GetKind())
+	assert.Equal(t, "foo", objs[0].GetName())
+}
+
+func TestParseManifest_InvalidYAMLErrors(t *testing.T) {
+	_, err := ParseManifest([]byte("foo: [unterminated"))
+	assert.Error(t, err)
+}

--- a/internal/operator/plan.go
+++ b/internal/operator/plan.go
@@ -1,0 +1,63 @@
+package operator
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/open-platform-model/cli/pkg/resourceorder"
+)
+
+const (
+	kindCustomResourceDefinition = "CustomResourceDefinition"
+	kindNamespace                = "Namespace"
+)
+
+// InstallPlan returns every manifest document ordered ascending by resource
+// weight (CRDs first, workloads last) — the order the objects must be applied in.
+func InstallPlan(objs []*unstructured.Unstructured) []*unstructured.Unstructured {
+	plan := append([]*unstructured.Unstructured(nil), objs...)
+	sortByWeightAscending(plan)
+	return plan
+}
+
+// CRDsOnlyPlan returns only the CustomResourceDefinition documents from objs,
+// ordered ascending by resource weight.
+func CRDsOnlyPlan(objs []*unstructured.Unstructured) []*unstructured.Unstructured {
+	var plan []*unstructured.Unstructured
+	for _, obj := range objs {
+		if obj.GetKind() == kindCustomResourceDefinition {
+			plan = append(plan, obj)
+		}
+	}
+	sortByWeightAscending(plan)
+	return plan
+}
+
+// UninstallPlan returns every manifest document except CustomResourceDefinitions
+// and the Namespace, ordered descending by resource weight (matching delete.go's
+// teardown convention). CRDs and the Namespace are deliberately excluded here —
+// uninstall must never remove them.
+func UninstallPlan(objs []*unstructured.Unstructured) []*unstructured.Unstructured {
+	var plan []*unstructured.Unstructured
+	for _, obj := range objs {
+		if kind := obj.GetKind(); kind == kindCustomResourceDefinition || kind == kindNamespace {
+			continue
+		}
+		plan = append(plan, obj)
+	}
+	sortByWeightDescending(plan)
+	return plan
+}
+
+func sortByWeightAscending(objs []*unstructured.Unstructured) {
+	sort.SliceStable(objs, func(i, j int) bool {
+		return resourceorder.GetWeight(objs[i].GroupVersionKind()) < resourceorder.GetWeight(objs[j].GroupVersionKind())
+	})
+}
+
+func sortByWeightDescending(objs []*unstructured.Unstructured) {
+	sort.SliceStable(objs, func(i, j int) bool {
+		return resourceorder.GetWeight(objs[i].GroupVersionKind()) > resourceorder.GetWeight(objs[j].GroupVersionKind())
+	})
+}

--- a/internal/operator/plan_test.go
+++ b/internal/operator/plan_test.go
@@ -1,0 +1,149 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func newObj(kind, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": apiVersionForKind(kind),
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name": name,
+		},
+	}}
+}
+
+// apiVersionForKind returns a plausible apiVersion for the given test fixture kind,
+// matching the group resourceorder.GetWeight looks up by GVK.
+func apiVersionForKind(kind string) string {
+	switch kind {
+	case "CustomResourceDefinition":
+		return "apiextensions.k8s.io/v1"
+	case "ClusterRole", "ClusterRoleBinding":
+		return "rbac.authorization.k8s.io/v1"
+	case "Deployment":
+		return "apps/v1"
+	default:
+		return "v1"
+	}
+}
+
+func fixtureManifest() []*unstructured.Unstructured {
+	return []*unstructured.Unstructured{
+		newObj("Deployment", "controller-manager"),
+		newObj("Namespace", "opm-operator-system"),
+		newObj("CustomResourceDefinition", "moduleinstances.opmodel.dev"),
+		newObj("ServiceAccount", "controller-manager"),
+		newObj("Service", "controller-manager-metrics"),
+		newObj("CustomResourceDefinition", "platforms.opmodel.dev"),
+		newObj("ClusterRole", "manager-role"),
+		newObj("ClusterRoleBinding", "manager-rolebinding"),
+	}
+}
+
+func TestInstallPlan_OrdersAscendingByWeight(t *testing.T) {
+	plan := InstallPlan(fixtureManifest())
+	require.Len(t, plan, 8)
+
+	kinds := kindsOf(plan)
+	assert.Equal(t, []string{
+		"CustomResourceDefinition",
+		"CustomResourceDefinition",
+		"Namespace",
+		"ClusterRole",
+		"ClusterRoleBinding",
+		"ServiceAccount",
+		"Service",
+		"Deployment",
+	}, kinds)
+}
+
+func TestInstallPlan_DoesNotMutateInput(t *testing.T) {
+	input := fixtureManifest()
+	original := kindsOf(input)
+
+	InstallPlan(input)
+
+	assert.Equal(t, original, kindsOf(input))
+}
+
+func TestCRDsOnlyPlan_ReturnsOnlyCRDs(t *testing.T) {
+	plan := CRDsOnlyPlan(fixtureManifest())
+	require.Len(t, plan, 2)
+	for _, obj := range plan {
+		assert.Equal(t, "CustomResourceDefinition", obj.GetKind())
+	}
+}
+
+func TestCRDsOnlyPlan_EmptyWhenNoCRDs(t *testing.T) {
+	objs := []*unstructured.Unstructured{newObj("Deployment", "d"), newObj("Service", "s")}
+	plan := CRDsOnlyPlan(objs)
+	assert.Empty(t, plan)
+}
+
+func TestUninstallPlan_OrdersDescendingByWeight(t *testing.T) {
+	plan := UninstallPlan(fixtureManifest())
+
+	kinds := kindsOf(plan)
+	assert.Equal(t, []string{
+		"Deployment",
+		"Service",
+		"ServiceAccount",
+		"ClusterRole",
+		"ClusterRoleBinding",
+	}, kinds)
+}
+
+// TestUninstallPlan_NeverIncludesCRDsOrNamespace is the property the design
+// relies on: uninstall must be structurally unable to remove CRDs or the
+// Namespace, across arbitrary manifest compositions.
+func TestUninstallPlan_NeverIncludesCRDsOrNamespace(t *testing.T) {
+	tests := []struct {
+		name string
+		objs []*unstructured.Unstructured
+	}{
+		{"full fixture manifest", fixtureManifest()},
+		{"CRDs and namespace only", []*unstructured.Unstructured{
+			newObj("CustomResourceDefinition", "a.opmodel.dev"),
+			newObj("CustomResourceDefinition", "b.opmodel.dev"),
+			newObj("Namespace", "opm-operator-system"),
+		}},
+		{"empty manifest", nil},
+		{"no CRDs or namespace", []*unstructured.Unstructured{
+			newObj("Deployment", "d"),
+			newObj("ClusterRole", "r"),
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := UninstallPlan(tt.objs)
+			for _, obj := range plan {
+				assert.NotEqual(t, "CustomResourceDefinition", obj.GetKind())
+				assert.NotEqual(t, "Namespace", obj.GetKind())
+			}
+		})
+	}
+}
+
+func TestUninstallPlan_DoesNotMutateInput(t *testing.T) {
+	input := fixtureManifest()
+	original := kindsOf(input)
+
+	UninstallPlan(input)
+
+	assert.Equal(t, original, kindsOf(input))
+}
+
+func kindsOf(objs []*unstructured.Unstructured) []string {
+	kinds := make([]string, len(objs))
+	for i, obj := range objs {
+		kinds[i] = obj.GetKind()
+	}
+	return kinds
+}

--- a/internal/operator/rbac.go
+++ b/internal/operator/rbac.go
@@ -1,0 +1,115 @@
+package operator
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// rbacClusterRoleName is the ClusterRole (and, when a subject is given, the
+// ClusterRoleBinding) --rbac emits.
+const rbacClusterRoleName = "opm-cli-user"
+
+const (
+	rbacAPIVersion    = "rbac.authorization.k8s.io/v1"
+	rbacAPIGroupField = "rbac.authorization.k8s.io"
+)
+
+// RBACOptions configures the optional opm-cli-user RBAC objects --rbac emits.
+type RBACOptions struct {
+	// Enabled turns on the opm-cli-user ClusterRole (and, when a subject is
+	// given, its ClusterRoleBinding).
+	Enabled bool
+
+	// User is the username to bind. Mutually exclusive with Group.
+	User string
+
+	// Group is the group name to bind. Mutually exclusive with User.
+	Group string
+}
+
+// Validate enforces that --user/--group are only used alongside --rbac,
+// and that at most one of them is set. Call before any cluster interaction.
+func (o RBACOptions) Validate() error {
+	if !o.Enabled && (o.User != "" || o.Group != "") {
+		return fmt.Errorf("--user/--group require --rbac")
+	}
+	if o.User != "" && o.Group != "" {
+		return fmt.Errorf("--user and --group are mutually exclusive")
+	}
+	return nil
+}
+
+// Objects returns the opm-cli-user ClusterRole and, if a subject (--user or
+// --group) is set, its ClusterRoleBinding. Returns nil when RBAC emission is
+// disabled.
+func (o RBACOptions) Objects() []*unstructured.Unstructured {
+	if !o.Enabled {
+		return nil
+	}
+
+	objs := []*unstructured.Unstructured{clusterRole()}
+
+	switch {
+	case o.User != "":
+		objs = append(objs, clusterRoleBinding("User", o.User))
+	case o.Group != "":
+		objs = append(objs, clusterRoleBinding("Group", o.Group))
+	}
+
+	return objs
+}
+
+// clusterRole builds the opm-cli-user ClusterRole: full verbs on
+// moduleinstances, get/patch/update on moduleinstances/status, get/list on
+// platforms.
+func clusterRole() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": rbacAPIVersion,
+		"kind":       "ClusterRole",
+		"metadata": map[string]any{
+			"name": rbacClusterRoleName,
+		},
+		"rules": []any{
+			map[string]any{
+				"apiGroups": []any{opmodelAPIGroup},
+				"resources": []any{moduleInstancesResource},
+				"verbs":     []any{"*"},
+			},
+			map[string]any{
+				"apiGroups": []any{opmodelAPIGroup},
+				"resources": []any{moduleInstancesResource + "/status"},
+				"verbs":     []any{"get", "patch", "update"},
+			},
+			map[string]any{
+				"apiGroups": []any{opmodelAPIGroup},
+				"resources": []any{"platforms"},
+				"verbs":     []any{"get", "list"},
+			},
+		},
+	}}
+}
+
+// clusterRoleBinding builds the ClusterRoleBinding for a single subject
+// ("User" or "Group") bound to the opm-cli-user ClusterRole.
+func clusterRoleBinding(subjectKind, subjectName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": rbacAPIVersion,
+		"kind":       "ClusterRoleBinding",
+		"metadata": map[string]any{
+			"name": rbacClusterRoleName,
+		},
+		"subjects": []any{
+			map[string]any{
+				"kind":     subjectKind,
+				"name":     subjectName,
+				"apiGroup": rbacAPIGroupField,
+			},
+		},
+		"roleRef": map[string]any{
+			"apiGroup": rbacAPIGroupField,
+			"kind":     "ClusterRole",
+			"name":     rbacClusterRoleName,
+		},
+	}}
+}

--- a/internal/operator/rbac_test.go
+++ b/internal/operator/rbac_test.go
@@ -1,0 +1,108 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRBACOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    RBACOptions
+		wantErr string
+	}{
+		{"disabled with no subject is valid", RBACOptions{}, ""},
+		{"enabled with no subject is valid", RBACOptions{Enabled: true}, ""},
+		{"enabled with user is valid", RBACOptions{Enabled: true, User: "alice"}, ""},
+		{"enabled with group is valid", RBACOptions{Enabled: true, Group: "platform-team"}, ""},
+		{"user without rbac is rejected", RBACOptions{User: "alice"}, "--user/--group require --rbac"},
+		{"group without rbac is rejected", RBACOptions{Group: "platform-team"}, "--user/--group require --rbac"},
+		{"user and group together is rejected", RBACOptions{Enabled: true, User: "alice", Group: "platform-team"}, "mutually exclusive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestRBACOptions_Objects_DisabledReturnsNone(t *testing.T) {
+	assert.Empty(t, RBACOptions{}.Objects())
+}
+
+func TestRBACOptions_Objects_EnabledWithoutSubjectIsRoleOnly(t *testing.T) {
+	objs := RBACOptions{Enabled: true}.Objects()
+	require.Len(t, objs, 1)
+	assert.Equal(t, "ClusterRole", objs[0].GetKind())
+	assert.Equal(t, "opm-cli-user", objs[0].GetName())
+}
+
+func TestRBACOptions_Objects_RoleShape(t *testing.T) {
+	objs := RBACOptions{Enabled: true}.Objects()
+	require.Len(t, objs, 1)
+	role := objs[0]
+
+	rules, found, err := unstructured.NestedSlice(role.Object, "rules")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, rules, 3)
+
+	rule := rules[0].(map[string]any)
+	assert.Equal(t, []any{"opmodel.dev"}, rule["apiGroups"])
+	assert.Equal(t, []any{"moduleinstances"}, rule["resources"])
+	assert.Equal(t, []any{"*"}, rule["verbs"])
+
+	statusRule := rules[1].(map[string]any)
+	assert.Equal(t, []any{"moduleinstances/status"}, statusRule["resources"])
+	assert.Equal(t, []any{"get", "patch", "update"}, statusRule["verbs"])
+
+	platformsRule := rules[2].(map[string]any)
+	assert.Equal(t, []any{"platforms"}, platformsRule["resources"])
+	assert.Equal(t, []any{"get", "list"}, platformsRule["verbs"])
+}
+
+func TestRBACOptions_Objects_UserSubjectAddsBinding(t *testing.T) {
+	objs := RBACOptions{Enabled: true, User: "alice"}.Objects()
+	require.Len(t, objs, 2)
+	assert.Equal(t, "ClusterRole", objs[0].GetKind())
+
+	binding := objs[1]
+	assert.Equal(t, "ClusterRoleBinding", binding.GetKind())
+	assert.Equal(t, "opm-cli-user", binding.GetName())
+
+	subjects, found, err := unstructured.NestedSlice(binding.Object, "subjects")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, subjects, 1)
+	subject := subjects[0].(map[string]any)
+	assert.Equal(t, "User", subject["kind"])
+	assert.Equal(t, "alice", subject["name"])
+
+	roleRef, found, err := unstructured.NestedMap(binding.Object, "roleRef")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "ClusterRole", roleRef["kind"])
+	assert.Equal(t, "opm-cli-user", roleRef["name"])
+}
+
+func TestRBACOptions_Objects_GroupSubjectAddsBinding(t *testing.T) {
+	objs := RBACOptions{Enabled: true, Group: "platform-team"}.Objects()
+	require.Len(t, objs, 2)
+
+	binding := objs[1]
+	subjects, _, err := unstructured.NestedSlice(binding.Object, "subjects")
+	require.NoError(t, err)
+	subject := subjects[0].(map[string]any)
+	assert.Equal(t, "Group", subject["kind"])
+	assert.Equal(t, "platform-team", subject["name"])
+}

--- a/internal/operator/uninstall.go
+++ b/internal/operator/uninstall.go
@@ -1,0 +1,219 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/open-platform-model/cli/internal/kubernetes"
+	"github.com/open-platform-model/cli/internal/output"
+)
+
+// opmodelAPIGroup and moduleInstancesResource identify the ModuleInstance CRD,
+// hardcoded rather than imported from opm-operator's types package — the CLI
+// has no Go module dependency on opm-operator (0006/D13).
+const (
+	opmodelAPIGroup         = "opmodel.dev"
+	moduleInstancesResource = "moduleinstances"
+)
+
+// moduleInstanceGVR is the ModuleInstance CRD's GroupVersionResource.
+var moduleInstanceGVR = schema.GroupVersionResource{
+	Group:    opmodelAPIGroup,
+	Version:  "v1alpha1",
+	Resource: moduleInstancesResource,
+}
+
+// cleanupFinalizer is the operator's finalizer that blocks uninstall until
+// removed or the ModuleInstance is otherwise cleaned up.
+const cleanupFinalizer = opmodelAPIGroup + "/cleanup"
+
+// ArmedInstance identifies a ModuleInstance still carrying the operator's
+// cleanup finalizer.
+type ArmedInstance struct {
+	Namespace string
+	Name      string
+}
+
+func (a ArmedInstance) String() string {
+	return fmt.Sprintf("%s/%s", a.Namespace, a.Name)
+}
+
+// FinalizerGuardError reports that uninstall was refused because one or more
+// ModuleInstances still carry the operator's cleanup finalizer.
+type FinalizerGuardError struct {
+	Armed []ArmedInstance
+}
+
+func (e *FinalizerGuardError) Error() string {
+	names := make([]string, len(e.Armed))
+	for i, a := range e.Armed {
+		names[i] = a.String()
+	}
+	return fmt.Sprintf(
+		"refusing to uninstall: %d instance(s) still carry the %s finalizer: %s (use --remove-finalizers to proceed; this orphans their workloads)",
+		len(e.Armed), cleanupFinalizer, strings.Join(names, ", "),
+	)
+}
+
+// CheckFinalizerGuard lists ModuleInstances cluster-wide and returns every
+// instance that still carries the operator's cleanup finalizer. A list
+// failure (including RBAC denial) is returned as-is so the caller fails
+// closed without deleting anything.
+func CheckFinalizerGuard(ctx context.Context, client *kubernetes.Client) ([]ArmedInstance, error) {
+	list, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing moduleinstances: %w", err)
+	}
+
+	var armed []ArmedInstance
+	for _, item := range list.Items {
+		for _, f := range item.GetFinalizers() {
+			if f == cleanupFinalizer {
+				armed = append(armed, ArmedInstance{Namespace: item.GetNamespace(), Name: item.GetName()})
+				break
+			}
+		}
+	}
+	return armed, nil
+}
+
+// RemoveCleanupFinalizer strips exactly the operator's cleanup finalizer from
+// every armed instance via a targeted JSON patch (test the finalizer is still
+// at the observed index, then remove it), leaving any other finalizers
+// intact. Reports the orphaning consequence for each instance it patches.
+// Every instance is attempted even if an earlier one fails — partial
+// failures are collected and returned together (mirroring kubernetes.Apply's
+// and kubernetes.Delete's per-resource error handling) so a failure on
+// instance N doesn't leave instances 1..N-1 already stripped with no
+// visibility into what happened.
+func RemoveCleanupFinalizer(ctx context.Context, client *kubernetes.Client, armed []ArmedInstance) error {
+	var errs []error
+	for _, a := range armed {
+		if err := removeOneCleanupFinalizer(ctx, client, a); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", a, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func removeOneCleanupFinalizer(ctx context.Context, client *kubernetes.Client, a ArmedInstance) error {
+	obj, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace(a.Namespace).Get(ctx, a.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("reading instance: %w", err)
+	}
+
+	idx := -1
+	for i, f := range obj.GetFinalizers() {
+		if f == cleanupFinalizer {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		// Already gone — a previous run or the operator itself removed it.
+		return nil
+	}
+
+	patch, err := json.Marshal([]map[string]any{
+		{"op": "test", "path": fmt.Sprintf("/metadata/finalizers/%d", idx), "value": cleanupFinalizer},
+		{"op": "remove", "path": fmt.Sprintf("/metadata/finalizers/%d", idx)},
+	})
+	if err != nil {
+		return fmt.Errorf("building finalizer patch: %w", err)
+	}
+
+	if _, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace(a.Namespace).Patch(
+		ctx, a.Name, types.JSONPatchType, patch, metav1.PatchOptions{},
+	); err != nil {
+		return fmt.Errorf("removing finalizer: %w", err)
+	}
+
+	output.Warn(fmt.Sprintf(
+		"removed %s finalizer from %s — its workload is now orphaned (no longer cleaned up by the operator)",
+		cleanupFinalizer, a,
+	))
+	return nil
+}
+
+// UninstallOptions configures an uninstall run.
+type UninstallOptions struct {
+	// RemoveFinalizers strips the operator's cleanup finalizer from any
+	// armed ModuleInstance before proceeding, orphaning its workload.
+	RemoveFinalizers bool
+}
+
+// UninstallResult reports the outcome of an uninstall run.
+type UninstallResult struct {
+	// Deleted is the number of resources deleted.
+	Deleted int
+
+	// Errors contains per-resource delete errors. Uninstall is fire-and-report:
+	// one resource failing to delete does not stop the rest.
+	Errors []error
+}
+
+// Uninstall deletes everything the embedded manifest installed except its
+// CRDs and Namespace, in descending resource-weight order (matching
+// delete.go's teardown convention). Before deleting anything it checks for
+// ModuleInstances still carrying the operator's cleanup finalizer and refuses
+// (or, with opts.RemoveFinalizers, strips the finalizer and proceeds).
+// Deletion does not wait for objects to fully disappear (fire-and-report):
+// nothing downstream depends on "fully gone", and waiting only adds failure
+// modes (stuck pod termination) to a command whose job is done at
+// delete-issuance.
+func Uninstall(ctx context.Context, client *kubernetes.Client, opts UninstallOptions) (*UninstallResult, error) {
+	armed, err := CheckFinalizerGuard(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	if len(armed) > 0 {
+		if !opts.RemoveFinalizers {
+			return nil, &FinalizerGuardError{Armed: armed}
+		}
+		if err := RemoveCleanupFinalizer(ctx, client, armed); err != nil {
+			return nil, err
+		}
+	}
+
+	manifest, err := EmbeddedManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	result := &UninstallResult{}
+	for _, obj := range UninstallPlan(manifest) {
+		if err := deleteOne(ctx, client, obj); err != nil {
+			output.Warn(fmt.Sprintf("deleting %s/%s: %v", obj.GetKind(), obj.GetName(), err))
+			result.Errors = append(result.Errors, fmt.Errorf("%s/%s: %w", obj.GetKind(), obj.GetName(), err))
+			continue
+		}
+		result.Deleted++
+		output.Info(output.FormatResourceLine(obj.GetKind(), obj.GetNamespace(), obj.GetName(), output.StatusDeleted))
+	}
+
+	return result, nil
+}
+
+// deleteOne deletes a single resource with foreground propagation, matching
+// kubernetes.Delete's per-resource behavior. A NotFound response counts as
+// success: uninstall is idempotent, and re-running it after a prior
+// successful (or partial) run is a natural user action.
+func deleteOne(ctx context.Context, client *kubernetes.Client, obj *unstructured.Unstructured) error {
+	propagation := metav1.DeletePropagationForeground
+	err := client.ResourceClient(kubernetes.GVRFromUnstructured(obj), obj.GetNamespace()).Delete(ctx, obj.GetName(), metav1.DeleteOptions{
+		PropagationPolicy: &propagation,
+	})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/operator/uninstall_test.go
+++ b/internal/operator/uninstall_test.go
@@ -1,0 +1,278 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/open-platform-model/cli/internal/kubernetes"
+)
+
+func moduleInstanceFixture(namespace, name string, finalizers ...string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "opmodel.dev/v1alpha1",
+		"kind":       "ModuleInstance",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}}
+	if len(finalizers) > 0 {
+		fs := make([]any, len(finalizers))
+		for i, f := range finalizers {
+			fs[i] = f
+		}
+		_ = unstructured.SetNestedSlice(obj.Object, fs, "metadata", "finalizers")
+	}
+	return obj
+}
+
+func TestCheckFinalizerGuard_FindsOnlyArmedInstances(t *testing.T) {
+	armedInst := moduleInstanceFixture("default", "jellyfin", cleanupFinalizer, "example.com/foreign")
+	cleanInst := moduleInstanceFixture("default", "redis")
+	client := fakeClientWith(armedInst, cleanInst)
+
+	armed, err := CheckFinalizerGuard(context.Background(), client)
+	require.NoError(t, err)
+	require.Len(t, armed, 1)
+	assert.Equal(t, ArmedInstance{Namespace: "default", Name: "jellyfin"}, armed[0])
+}
+
+func TestCheckFinalizerGuard_NoInstancesReturnsEmpty(t *testing.T) {
+	client := fakeClientWith()
+	armed, err := CheckFinalizerGuard(context.Background(), client)
+	require.NoError(t, err)
+	assert.Empty(t, armed)
+}
+
+func TestCheckFinalizerGuard_ListFailureFailsClosed(t *testing.T) {
+	client := fakeClientWith()
+	fake, ok := client.Dynamic.(interface {
+		PrependReactor(verb, resource string, reaction k8stesting.ReactionFunc)
+	})
+	require.True(t, ok)
+	fake.PrependReactor("list", "moduleinstances", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden: user cannot list moduleinstances")
+	})
+
+	_, err := CheckFinalizerGuard(context.Background(), client)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "listing moduleinstances")
+}
+
+func TestFinalizerGuardError_NamesArmedInstances(t *testing.T) {
+	err := &FinalizerGuardError{Armed: []ArmedInstance{{Namespace: "default", Name: "jellyfin"}}}
+	assert.ErrorContains(t, err, "default/jellyfin")
+	assert.ErrorContains(t, err, "--remove-finalizers")
+	assert.ErrorContains(t, err, cleanupFinalizer)
+}
+
+func TestRemoveCleanupFinalizer_RemovesOnlyTheCleanupFinalizer(t *testing.T) {
+	inst := moduleInstanceFixture("default", "jellyfin", cleanupFinalizer, "example.com/foreign")
+	client := fakeClientWith(inst)
+
+	armed := []ArmedInstance{{Namespace: "default", Name: "jellyfin"}}
+	err := RemoveCleanupFinalizer(context.Background(), client, armed)
+	require.NoError(t, err)
+
+	live, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace("default").Get(context.Background(), "jellyfin", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"example.com/foreign"}, live.GetFinalizers())
+}
+
+func TestRemoveCleanupFinalizer_MissingFinalizerIsANoop(t *testing.T) {
+	inst := moduleInstanceFixture("default", "jellyfin", "example.com/foreign")
+	client := fakeClientWith(inst)
+
+	armed := []ArmedInstance{{Namespace: "default", Name: "jellyfin"}}
+	err := RemoveCleanupFinalizer(context.Background(), client, armed)
+	require.NoError(t, err)
+
+	live, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace("default").Get(context.Background(), "jellyfin", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"example.com/foreign"}, live.GetFinalizers())
+}
+
+func TestRemoveCleanupFinalizer_MultipleInstances(t *testing.T) {
+	instA := moduleInstanceFixture("default", "jellyfin", cleanupFinalizer)
+	instB := moduleInstanceFixture("media", "seerr", cleanupFinalizer, "example.com/foreign")
+	client := fakeClientWith(instA, instB)
+
+	armed := []ArmedInstance{
+		{Namespace: "default", Name: "jellyfin"},
+		{Namespace: "media", Name: "seerr"},
+	}
+	require.NoError(t, RemoveCleanupFinalizer(context.Background(), client, armed))
+
+	liveA, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace("default").Get(context.Background(), "jellyfin", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, liveA.GetFinalizers())
+
+	liveB, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace("media").Get(context.Background(), "seerr", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"example.com/foreign"}, liveB.GetFinalizers())
+}
+
+func TestRemoveCleanupFinalizer_ContinuesPastAFailureAndReturnsCombinedError(t *testing.T) {
+	instA := moduleInstanceFixture("default", "jellyfin", cleanupFinalizer)
+	instB := moduleInstanceFixture("media", "seerr", cleanupFinalizer)
+	client := fakeClientWith(instA, instB)
+
+	fake, ok := client.Dynamic.(interface {
+		PrependReactor(verb, resource string, reaction k8stesting.ReactionFunc)
+	})
+	require.True(t, ok)
+	fake.PrependReactor("patch", "moduleinstances", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if ok && patchAction.GetName() == "jellyfin" {
+			return true, nil, errors.New("transient conflict")
+		}
+		return false, nil, nil
+	})
+
+	armed := []ArmedInstance{
+		{Namespace: "default", Name: "jellyfin"},
+		{Namespace: "media", Name: "seerr"},
+	}
+	err := RemoveCleanupFinalizer(context.Background(), client, armed)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "default/jellyfin")
+
+	// The failing instance is untouched.
+	liveA, getErr := client.Dynamic.Resource(moduleInstanceGVR).Namespace("default").Get(context.Background(), "jellyfin", metav1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.Equal(t, []string{cleanupFinalizer}, liveA.GetFinalizers())
+
+	// The later instance still got processed despite the earlier failure —
+	// the loop no longer aborts on the first error.
+	liveB, getErr := client.Dynamic.Resource(moduleInstanceGVR).Namespace("media").Get(context.Background(), "seerr", metav1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.Empty(t, liveB.GetFinalizers())
+}
+
+func TestUninstall_RemoveFinalizersPartialFailureDoesNotDeleteResources(t *testing.T) {
+	instA := moduleInstanceFixture("default", "jellyfin", cleanupFinalizer)
+	instB := moduleInstanceFixture("media", "seerr", cleanupFinalizer)
+	manifest, err := EmbeddedManifest()
+	require.NoError(t, err)
+	plan := UninstallPlan(manifest)
+	client := fakeClientWith(append([]*unstructured.Unstructured{instA, instB}, plan...)...)
+
+	fake, ok := client.Dynamic.(interface {
+		PrependReactor(verb, resource string, reaction k8stesting.ReactionFunc)
+	})
+	require.True(t, ok)
+	fake.PrependReactor("patch", "moduleinstances", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if ok && patchAction.GetName() == "jellyfin" {
+			return true, nil, errors.New("transient conflict")
+		}
+		return false, nil, nil
+	})
+
+	result, err := Uninstall(context.Background(), client, UninstallOptions{RemoveFinalizers: true})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorContains(t, err, "default/jellyfin")
+
+	// seerr was stripped — processing continued past jellyfin's failure.
+	liveB, getErr := client.Dynamic.Resource(moduleInstanceGVR).Namespace("media").Get(context.Background(), "seerr", metav1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.Empty(t, liveB.GetFinalizers())
+
+	// The operator's own resources were never touched: Uninstall must not
+	// proceed to its delete loop while any armed instance failed to strip.
+	_, err = client.Dynamic.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).
+		Namespace("opm-operator-system").Get(context.Background(), "opm-operator-controller-manager", metav1.GetOptions{})
+	require.NoError(t, err, "Deployment should still exist")
+}
+
+func TestUninstall_IsIdempotentWhenNothingLeftToDelete(t *testing.T) {
+	client := fakeClientWith() // Nothing pre-seeded — simulates "already uninstalled".
+
+	result, err := Uninstall(context.Background(), client, UninstallOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Errors)
+}
+
+func TestUninstall_RefusesWhenArmedAndRemoveFinalizersFalse(t *testing.T) {
+	inst := moduleInstanceFixture("default", "jellyfin", cleanupFinalizer)
+	client := fakeClientWith(inst)
+
+	result, err := Uninstall(context.Background(), client, UninstallOptions{RemoveFinalizers: false})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	var guardErr *FinalizerGuardError
+	require.ErrorAs(t, err, &guardErr)
+	assert.Equal(t, []ArmedInstance{{Namespace: "default", Name: "jellyfin"}}, guardErr.Armed)
+
+	// Nothing else was touched: the instance still exists with the finalizer intact.
+	live, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace("default").Get(context.Background(), "jellyfin", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{cleanupFinalizer}, live.GetFinalizers())
+}
+
+func TestUninstall_RemoveFinalizersStripsAndProceeds(t *testing.T) {
+	inst := moduleInstanceFixture("default", "jellyfin", cleanupFinalizer)
+	manifest, err := EmbeddedManifest()
+	require.NoError(t, err)
+	plan := UninstallPlan(manifest)
+	client := fakeClientWith(append([]*unstructured.Unstructured{inst}, plan...)...)
+
+	result, err := Uninstall(context.Background(), client, UninstallOptions{RemoveFinalizers: true})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, len(plan), result.Deleted)
+	assert.Empty(t, result.Errors)
+
+	live, err := client.Dynamic.Resource(moduleInstanceGVR).Namespace("default").Get(context.Background(), "jellyfin", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, live.GetFinalizers())
+
+	_, err = client.Dynamic.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).
+		Namespace("opm-operator-system").Get(context.Background(), "opm-operator-controller-manager", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestUninstall_NoArmedInstancesDeletesEverythingInPlan(t *testing.T) {
+	manifest, err := EmbeddedManifest()
+	require.NoError(t, err)
+	plan := UninstallPlan(manifest)
+	client := fakeClientWith(plan...)
+
+	result, err := Uninstall(context.Background(), client, UninstallOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, len(plan), result.Deleted)
+	assert.Empty(t, result.Errors)
+}
+
+func TestUninstall_NeverTargetsCRDsOrNamespace(t *testing.T) {
+	manifest, err := EmbeddedManifest()
+	require.NoError(t, err)
+	// Seed the full manifest, including CRDs and the Namespace, to prove
+	// Uninstall leaves them alone even though they're present on the "cluster".
+	client := fakeClientWith(manifest...)
+
+	result, err := Uninstall(context.Background(), client, UninstallOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, result.Errors)
+
+	for _, obj := range manifest {
+		if obj.GetKind() != kindCustomResourceDefinition && obj.GetKind() != kindNamespace {
+			continue
+		}
+		live, err := client.Dynamic.Resource(kubernetes.GVRFromUnstructured(obj)).Namespace(obj.GetNamespace()).Get(context.Background(), obj.GetName(), metav1.GetOptions{})
+		require.NoError(t, err, "CRD/Namespace should not have been deleted")
+		assert.NotNil(t, live)
+	}
+}

--- a/internal/operator/wait.go
+++ b/internal/operator/wait.go
@@ -1,0 +1,127 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/open-platform-model/cli/internal/kubernetes"
+)
+
+// waitPollInterval is how often Wait re-checks target readiness.
+const waitPollInterval = 2 * time.Second
+
+const (
+	kindDeployment       = "Deployment"
+	conditionStatusTrue  = "True"
+	conditionEstablished = "Established"
+)
+
+// ReadyPredicate reports whether a live object (as currently observed on the
+// cluster) is ready.
+type ReadyPredicate func(obj *unstructured.Unstructured) bool
+
+// DefaultPredicate dispatches to the readiness check appropriate for obj's
+// kind: CRD Established=True for CustomResourceDefinitions, workload rollout
+// health (via kubernetes.EvaluateHealth) for Deployments. Other kinds are
+// considered ready as soon as they exist.
+func DefaultPredicate(obj *unstructured.Unstructured) bool {
+	switch obj.GetKind() {
+	case kindCustomResourceDefinition:
+		return CRDEstablishedPredicate(obj)
+	case kindDeployment:
+		return WorkloadReadyPredicate(obj)
+	default:
+		return true
+	}
+}
+
+// CRDEstablishedPredicate reports whether a CustomResourceDefinition has
+// reached the Established=True condition.
+func CRDEstablishedPredicate(obj *unstructured.Unstructured) bool {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, raw := range conditions {
+		c, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		condType, _, _ := unstructured.NestedString(c, "type")     //nolint:errcheck // best-effort condition parsing
+		condStatus, _, _ := unstructured.NestedString(c, "status") //nolint:errcheck // best-effort condition parsing
+		if condType == conditionEstablished && condStatus == conditionStatusTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// WorkloadReadyPredicate reports whether a workload resource (e.g. a
+// Deployment) has completed its rollout, reusing the same health evaluation
+// the rest of the CLI uses for instance status.
+func WorkloadReadyPredicate(obj *unstructured.Unstructured) bool {
+	return kubernetes.IsHealthy(kubernetes.EvaluateHealth(obj))
+}
+
+// Wait polls the live state of each object on the cluster until predicate
+// reports every one ready, or timeout elapses. Bounded and context-cancellable.
+// Objects that no longer exist (e.g. a Get error) count as not yet ready.
+func Wait(ctx context.Context, client *kubernetes.Client, objs []*unstructured.Unstructured, predicate ReadyPredicate, timeout time.Duration) error {
+	return wait(ctx, client, objs, predicate, timeout, waitPollInterval)
+}
+
+func wait(ctx context.Context, client *kubernetes.Client, objs []*unstructured.Unstructured, predicate ReadyPredicate, timeout, pollInterval time.Duration) error {
+	if len(objs) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	remaining := objs
+	for {
+		remaining = pendingObjects(ctx, client, remaining, predicate)
+		if len(remaining) == 0 {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out after %s waiting for %s to become ready", timeout, describeObjects(remaining))
+		case <-ticker.C:
+		}
+	}
+}
+
+// pendingObjects fetches the live state of each object and returns those
+// that don't yet satisfy predicate.
+func pendingObjects(ctx context.Context, client *kubernetes.Client, objs []*unstructured.Unstructured, predicate ReadyPredicate) []*unstructured.Unstructured {
+	var pending []*unstructured.Unstructured
+	for _, obj := range objs {
+		live, err := client.ResourceClient(kubernetes.GVRFromUnstructured(obj), obj.GetNamespace()).Get(ctx, obj.GetName(), metav1.GetOptions{})
+		if err != nil || !predicate(live) {
+			pending = append(pending, obj)
+		}
+	}
+	return pending
+}
+
+func describeObjects(objs []*unstructured.Unstructured) string {
+	names := make([]string, len(objs))
+	for i, obj := range objs {
+		if ns := obj.GetNamespace(); ns != "" {
+			names[i] = fmt.Sprintf("%s/%s in %s", obj.GetKind(), obj.GetName(), ns)
+		} else {
+			names[i] = fmt.Sprintf("%s/%s", obj.GetKind(), obj.GetName())
+		}
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/operator/wait_test.go
+++ b/internal/operator/wait_test.go
@@ -1,0 +1,137 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+
+	"github.com/open-platform-model/cli/internal/kubernetes"
+)
+
+func crdFixture(established bool) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata": map[string]any{
+			"name": "moduleinstances.opmodel.dev",
+		},
+	}}
+	if established {
+		_ = unstructured.SetNestedSlice(obj.Object, []any{
+			map[string]any{"type": "Established", "status": "True"},
+		}, "status", "conditions")
+	}
+	return obj
+}
+
+func deploymentFixture(ready bool) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "opm-operator-controller-manager",
+			"namespace": "opm-operator-system",
+		},
+	}}
+	if ready {
+		_ = unstructured.SetNestedSlice(obj.Object, []any{
+			map[string]any{"type": "Available", "status": "True"},
+		}, "status", "conditions")
+	}
+	return obj
+}
+
+func TestCRDEstablishedPredicate(t *testing.T) {
+	assert.False(t, CRDEstablishedPredicate(crdFixture(false)))
+	assert.True(t, CRDEstablishedPredicate(crdFixture(true)))
+}
+
+func TestWorkloadReadyPredicate(t *testing.T) {
+	assert.False(t, WorkloadReadyPredicate(deploymentFixture(false)))
+	assert.True(t, WorkloadReadyPredicate(deploymentFixture(true)))
+}
+
+func TestDefaultPredicate_DispatchesByKind(t *testing.T) {
+	assert.True(t, DefaultPredicate(crdFixture(true)))
+	assert.False(t, DefaultPredicate(crdFixture(false)))
+	assert.True(t, DefaultPredicate(deploymentFixture(true)))
+	assert.False(t, DefaultPredicate(deploymentFixture(false)))
+
+	// Passive kinds are ready as soon as they exist.
+	svc := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata":   map[string]any{"name": "opm-operator-metrics"},
+	}}
+	assert.True(t, DefaultPredicate(svc))
+}
+
+func fakeClientWith(objs ...*unstructured.Unstructured) *kubernetes.Client {
+	scheme := runtime.NewScheme()
+	runtimeObjs := make([]runtime.Object, len(objs))
+	for i, o := range objs {
+		runtimeObjs[i] = o
+	}
+	// Custom resources (e.g. ModuleInstance) need an explicit GVR->ListKind
+	// mapping: the fake tracker only infers one from pre-seeded objects, so
+	// an empty-fixture test (no objects of that kind) would otherwise panic
+	// on List with "you must register resource to list kind".
+	listKinds := map[schema.GroupVersionResource]string{
+		moduleInstanceGVR: "ModuleInstanceList",
+	}
+	return &kubernetes.Client{Dynamic: fakedynamic.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, runtimeObjs...)}
+}
+
+func TestWait_ReturnsNilOnceObjectBecomesReady(t *testing.T) {
+	notReady := crdFixture(false)
+	client := fakeClientWith(notReady)
+
+	// Flip the CRD to Established=True shortly after the wait starts.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		ready := crdFixture(true)
+		_, err := client.ResourceClient(kubernetes.GVRFromUnstructured(ready), "").Update(context.Background(), ready, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+	}()
+
+	err := wait(context.Background(), client, []*unstructured.Unstructured{notReady}, DefaultPredicate, time.Second, 5*time.Millisecond)
+	require.NoError(t, err)
+}
+
+func TestWait_TimesOutNamingTheUnreadyObject(t *testing.T) {
+	notReady := crdFixture(false)
+	client := fakeClientWith(notReady)
+
+	err := wait(context.Background(), client, []*unstructured.Unstructured{notReady}, DefaultPredicate, 20*time.Millisecond, 5*time.Millisecond)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "moduleinstances.opmodel.dev")
+	assert.ErrorContains(t, err, "timed out")
+}
+
+func TestWait_EmptyObjectsReturnsImmediately(t *testing.T) {
+	client := fakeClientWith()
+	err := wait(context.Background(), client, nil, DefaultPredicate, time.Millisecond, time.Millisecond)
+	require.NoError(t, err)
+}
+
+func TestWait_ContextCancellationStopsWait(t *testing.T) {
+	notReady := crdFixture(false)
+	client := fakeClientWith(notReady)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err := wait(ctx, client, []*unstructured.Unstructured{notReady}, DefaultPredicate, 5*time.Second, 5*time.Millisecond)
+	require.Error(t, err)
+}

--- a/openspec/changes/archive/2026-07-03-cli-operator-install-command/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-03-cli-operator-install-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/archive/2026-07-03-cli-operator-install-command/design.md
+++ b/openspec/changes/archive/2026-07-03-cli-operator-install-command/design.md
@@ -1,0 +1,98 @@
+# Design: cli-operator-install-command
+
+## Context
+
+Enhancement 0006 fixed the product surface in its decision log — noun-first `opm operator install [--crds-only] [--rbac]` / `opm operator uninstall [--remove-finalizers]` (D32), install/uninstall-only scope with the `opm-cli` field-manager rename (D33), uninstall safety semantics (D34), single embedded artifact + pin + fetch + readiness wait (D35). This design does not re-litigate those; it decides how they map onto the CLI codebase.
+
+Current state that shapes the design:
+
+- `internal/kubernetes` has the client (`client.go`, dynamic + clientset, cached), SSA apply (`apply.go`, `ApplyPatchType` + `Force: true`, field manager from the `fieldManagerName` constant in `labels.go`), delete (`delete.go`, already sorts descending by weight), and per-resource health evaluation (`health.go`).
+- `pkg/resourceorder` weights already encode the install order this slice needs: CRD (−100) → Namespace (0) → ClusterRole/Binding (5) → SA/Role/Binding (10) → Service (50) → Deployment (100).
+- Nothing in the CLI parses multi-document YAML (all manifests arrive via CUE render) and nothing polls a cluster for readiness (`k8s.io/apimachinery/pkg/util/wait` is only a transitive dep).
+- opm-operator's `dist/install.yaml` (16 docs: 3 CRDs, 1 Namespace, RBAC set, Deployment, Service) is uploaded as a GitHub release asset by its `release.yml`. Tag `v1.0.0-alpha.2` contains 0006 slices A1 (dependency line) and A4 (`spec.owner` CRD).
+- No existing spec pins the current `opm` field-manager string, so the rename is spec-clean; the new `operator-lifecycle` spec owns the `opm-cli` requirement.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `opm operator install/uninstall` per D32–D35, with all cluster writes attributed to field manager `opm-cli`.
+- One embedded artifact; CRD subset always derived by filtering, structurally unable to drift from the full install.
+- Bounded, observable readiness waits whose machinery slice C3 (`instance handoff`) can reuse for its "operator installed and ready" precondition.
+- Uninstall that cannot wedge the cluster: CRDs and Namespace preserved, finalizer refusal by default.
+
+**Non-Goals:**
+
+- No apply-path changes: no missing-CRD hint, no version-skew gates — C1's scope (D33).
+- No operator upgrade orchestration; `install` is idempotent SSA, not a package manager (0006 README out-of-scope).
+- No checksum/signature verification of fetched artifacts (deferred by D35).
+- No reconciliation of `--version`-fetched vs embedded CRD schema differences — the CLI-≥-cluster contract is C1's gate (D24).
+
+## Decisions
+
+### 1. Two packages: thin `internal/cmd/operator/`, logic in `internal/operator/`
+
+`internal/cmd/operator/` holds cobra wiring only (`operator.go` group, `install.go`, `uninstall.go`), matching the `internal/cmd/instance/` pattern and Constitution II ("commands orchestrate"). All behavior — embed, parse, plan, apply/delete loops, waits, finalizer guard, fetch — lives in a new `internal/operator/` package. Not `pkg/`: this is CLI-product behavior with no reuse ambition outside the CLI.
+
+*Alternative — fold logic into `internal/kubernetes`:* rejected; that package is generic cluster primitives, and the operator-manifest lifecycle (pinning, filtering, GitHub fetch) is a distinct concern that would bloat it.
+
+### 2. Export a single-resource SSA helper instead of reusing `kubernetes.Apply`
+
+`kubernetes.Apply` is instance-shaped: `instanceName` parameter, `output.InstanceLogger`, instance-flavored result counters. Rather than generalize its signature (touching the instance apply path this slice must not disturb), promote the existing unexported `applyResource` to an exported single-resource primitive (e.g. `ApplyOne(ctx, client, obj, opts) (status, error)`) and have both `kubernetes.Apply` and the operator install loop call it. The install loop owns its own reporting (per-doc status lines via `output.FormatResourceLine`).
+
+*Alternative — parameterize `Apply` with a logger/label:* rejected; widens a stable API for one caller and couples operator output style to instance output style.
+
+### 3. Manifest handling: parse once, plan by filtering
+
+`internal/operator` embeds `dist/install.yaml` and parses it into `[]*unstructured.Unstructured` using `k8s.io/apimachinery/pkg/util/yaml`'s multi-doc decoder (no new dependency). Three pure functions derive plans from one parsed set:
+
+- install plan = all docs, sorted ascending by `pkg/resourceorder` weight;
+- CRDs-only plan = docs where `kind == CustomResourceDefinition`;
+- uninstall plan = all docs minus CRDs minus the Namespace, sorted descending (matching `delete.go`'s teardown convention).
+
+Pure functions over parsed docs keep everything unit-testable without a cluster, and make "uninstall never touches CRDs/Namespace" a property of the plan, not of scattered `if` checks in the delete loop.
+
+### 4. Pin + refresh: one constant next to the embed, `task operator:sync`
+
+The pinned tag lives as a single Go constant (e.g. `internal/operator/manifest.go: PinnedOperatorVersion = "v1.0.0-alpha.2"`) beside the `go:embed` directive. `task operator:sync VERSION=<tag>` downloads `https://github.com/open-platform-model/opm-operator/releases/download/<tag>/install.yaml` into the embed location and rewrites the constant — the whole upgrade is one reviewable diff. `--version <tag>` at runtime fetches the same URL over HTTPS (10–30s timeout, clear error on 404 naming the tag) and feeds the identical parse/plan path; per D35 no checksum verification.
+
+*Alternative — infer the pin from `go.mod` or a config file:* rejected; the CLI has no Go dependency on opm-operator (0006/D13 forbids the module edge), and a config file adds a second source of truth for what is a build-time property.
+
+### 5. Readiness waits: new bounded poll in `internal/operator`, condition checks from `health.go` where they fit
+
+No polling machinery exists; build a small bounded wait (poll every 2s against `--timeout`, default `5m`, context-cancellable) in `internal/operator`:
+
+- CRDs: wait for condition `Established=True` on each applied CRD (custom check — `health.go` has no CRD case).
+- Full install: CRDs `Established`, then the operator Deployment ready — reuse `kubernetes.EvaluateHealth`'s workload path against the live Deployment object.
+
+The wait function takes a set of target objects and a per-object readiness predicate, so C3's "operator installed and ready" precondition can call the same code with the same predicates. Uninstall does **not** wait for deletion to complete (fire-and-report): nothing downstream consumes "fully gone", and waiting adds failure modes (stuck pod termination) to a command whose job is done at delete-issuance.
+
+### 6. Finalizer guard: read via dynamic client, strip only `opmodel.dev/cleanup`
+
+Before deleting anything, uninstall lists `moduleinstances` cluster-wide via the existing dynamic client (GVR hardcoded in `internal/operator`; the CLI deliberately has no opm-operator type imports per 0006/D13). Any instance whose `metadata.finalizers` contains `opmodel.dev/cleanup` triggers the refusal, listing each `namespace/name`. With `--remove-finalizers`, the CLI removes exactly that finalizer via a JSON patch on each instance, prints the orphaning consequence, then proceeds. RBAC failure on the list (user can delete Deployments but not list moduleinstances) fails closed with the standard `cmdutil.ExitCodeFromK8sError` mapping — uninstall does not proceed blind.
+
+*Alternative — strategic-merge or SSA for finalizer removal:* rejected; finalizers is a shared list not owned by `opm-cli`, a targeted JSON patch (test-and-remove) is the precise, minimal write.
+
+### 7. `--rbac` is valid with and without `--crds-only`
+
+D23/D32 word `--rbac` against the CRDs-only path (its motivating user), but a full-install cluster whose CLI drivers are non-admins is coherent. The flag emits the `opm-cli-user` ClusterRole (full verbs on `moduleinstances`, get/patch/update on `moduleinstances/status`, get/list on `platforms`) and, when `--user`/`--group` is given, one ClusterRoleBinding. Objects are constructed in Go as `unstructured` (not embedded YAML templates — they take runtime parameters). `--user`/`--group` without `--rbac` is a flag-validation error (fail-early, Constitution I).
+
+### 8. Field-manager rename is a one-constant change, sequenced first
+
+`internal/kubernetes/labels.go: fieldManagerName = "opm"` → `"opm-cli"`. The only SSA write site is `apply.go`; ownership of previously-applied resources transfers on next apply through the existing `Force: true`. Landed as the first task so every new write this slice adds is born under the final manager name. No transition handling: no external users (0006/D14).
+
+## Risks / Trade-offs
+
+- **[E2E needs the operator image]** The kind-cluster e2e's rollout wait requires pulling the pinned operator image from GHCR (or preloading it). → Verify pull access in the e2e environment first; if unavailable, e2e asserts through CRD `Established` + Deployment *created*, and rollout-ready is covered by a documented manual/integration path.
+- **[Fetched `--version` artifact skew]** A newer fetched `install.yaml` may carry CRDs/fields this CLI predates; nothing gates that here. → Accepted for this slice; D24's CLI-≥-cluster gate lands in C1. `--version` output names the tag it installed.
+- **[Finalizer strip races the operator]** If the operator is still running when `--remove-finalizers` strips, a concurrent reconcile may re-add finalizers. → Acceptable: uninstall deletes the Deployment immediately after; a re-added finalizer just re-triggers the refusal on a rerun, which is safe and visible.
+- **[Field ownership transfer noise]** After the rename, the first re-apply of pre-existing releases shows all fields migrating `opm` → `opm-cli` in managedFields. → Cosmetic; no behavior change (`Force: true` preexists). Noted in the task so reviewers aren't surprised by e2e managedFields diffs.
+- **[GitHub fetch is a new failure surface]** Air-gapped or rate-limited environments can't use `--version`. → The embedded default needs no network; the error message says to use the embedded version or `task operator:sync` from a connected machine.
+
+## Migration Plan
+
+Forward-only, additive. No data migration; no existing command changes flags or output. Rollback = revert the commits — the field-manager rename reverts symmetrically (ownership transfers back on next apply the same way).
+
+## Open Questions
+
+None blocking. Flag defaults chosen here (poll 2s, `--timeout 5m`, fetch timeout 30s) are implementation-tunable without spec impact.

--- a/openspec/changes/archive/2026-07-03-cli-operator-install-command/proposal.md
+++ b/openspec/changes/archive/2026-07-03-cli-operator-install-command/proposal.md
@@ -1,0 +1,39 @@
+# Proposal: cli-operator-install-command
+
+> Slice B2 of enhancement `0006` (CLI CR Inventory, Library Kernel Adoption, and Operator Handoff). Implements decisions D5, D23 (install-side half), D32, D33, D34, D35.
+
+## Why
+
+Enhancement 0006 moves the CLI's release inventory into the operator's `ModuleInstance` CR (slice C1), which makes the CRDs a hard prerequisite for every CLI apply — and handoff (slice C3) requires a running operator. Today the CLI has no way to put either onto a cluster; users must clone `opm-operator` or hand-fetch manifests. This slice gives the CLI an explicit, self-contained operator lifecycle surface so the C1/C3 slices land onto clusters the CLI itself can prepare.
+
+## What Changes
+
+- New `opm operator` command group (noun-first per 0006/D32):
+  - `opm operator install` — SSA-applies the full embedded operator manifest (`dist/install.yaml` of a pinned opm-operator release) and waits, bounded, for completion (CRDs `Established`, operator Deployment rollout).
+  - `opm operator install --crds-only` — applies only the `CustomResourceDefinition` documents filtered from the same artifact (the CLI-solo path); waits for `Established`.
+  - `opm operator install --rbac [--user U | --group G]` — additionally emits an `opm-cli-user` ClusterRole (verbs on `moduleinstances`, `moduleinstances/status`, read on `platforms`), binding it when `--user`/`--group` is given (0006/D23). Off by default.
+  - `opm operator install --version <tag>` — fetches `install.yaml` from the corresponding opm-operator GitHub release instead of using the embedded copy.
+  - `opm operator uninstall` — deletes what install applied **except** CRDs and the Namespace (0006/D34). Refuses (naming the instances) while any `ModuleInstance` carries the operator's `opmodel.dev/cleanup` finalizer; `--remove-finalizers` strips that finalizer (only that one) and proceeds, stating the orphaning consequence.
+- One embedded artifact: the pinned release's `dist/install.yaml` via `go:embed`; CRD subset derived by filtering, never a second embedded copy (0006/D35). Pin recorded in one constant; new `task operator:sync VERSION=<tag>` refreshes artifact + pin.
+- **BREAKING (internal only):** the CLI's SSA field manager renames `opm` → `opm-cli` (0006/D33, D10 naming). Field ownership of previously-applied resources transfers on next apply via the existing `Force: true`; no user-visible flag or output changes. The CLI has no external users (0006/D14), so no compatibility shim.
+- Explicitly **not** in this slice (0006/D33): no apply-path changes — the missing-CRD hint and version-skew gates land with the CR-inventory slice (C1).
+
+SemVer: **MINOR** (new command group and flags with defaults; no existing command's flags or output change).
+
+## Capabilities
+
+### New Capabilities
+
+- `operator-lifecycle`: the `opm operator install`/`uninstall` command surface — embedded pinned manifest, CRD-subset filtering, version fetch fallback, RBAC emission, bounded readiness waits, uninstall safety (CRD/Namespace preservation, finalizer refusal + `--remove-finalizers`), and the `opm-cli` field manager for all CLI server-side-apply writes.
+
+### Modified Capabilities
+
+- `cmd-structure`: the command-package organization requirement gains the `internal/cmd/operator/` package (new top-level command group joining `module`, `instance`, `config`).
+
+## Impact
+
+- **New packages:** `internal/cmd/operator/` (thin cobra commands), `internal/operator/` (embed, manifest parse/filter/plan, readiness wait, finalizer guard, release fetch).
+- **Modified:** `internal/kubernetes/labels.go` (field-manager constant rename; the one SSA write site is `internal/kubernetes/apply.go`), `internal/cmd/root.go` (group wiring), `Taskfile.yml` (`operator:sync`), `README.md` (command groups).
+- **Reused, unchanged behavior:** `internal/kubernetes` client/apply/delete/health primitives, `pkg/resourceorder` weights (already order CRD → Namespace → RBAC → Deployment; teardown already sorts descending), `cmdutil` k8s client + exit-code mapping, `internal/output` status lines.
+- **Dependencies:** no new Go modules expected — multi-doc YAML decoding and polling come from `k8s.io/apimachinery` (already direct/transitive). First outbound HTTPS call in the k8s path (`--version` fetch to GitHub releases; no checksum verification at this stage per 0006/D35).
+- **Coordination:** embeds opm-operator `v1.0.0-alpha.2` (first pin — already contains 0006 slices A1 and A4). Unblocks slice C1 (`cli-cr-inventory-backend`), which also consumes new slice A6 (`Platform.status.operatorVersion`).

--- a/openspec/changes/archive/2026-07-03-cli-operator-install-command/specs/cmd-structure/spec.md
+++ b/openspec/changes/archive/2026-07-03-cli-operator-install-command/specs/cmd-structure/spec.md
@@ -1,0 +1,46 @@
+# cmd-structure (delta)
+
+Adds the `operator` command group to the command-package organization (slice B2 of enhancement 0006, D32).
+
+## MODIFIED Requirements
+
+### Requirement: Command packages are organised by command group
+
+The `internal/cmd/` package SHALL be split into sub-packages that mirror the cobra command tree.
+
+#### Scenario: module commands are in their own package
+
+- **WHEN** the `internal/cmd/module/` directory is inspected
+- **THEN** it SHALL contain module authoring commands: `init`, `vet`, `build`
+- **AND** the `build` subcommand SHALL synthesize a `#ModuleInstance` from a module-package directory and render it through the shared instance-render pipeline
+- **AND** the `build` subcommand SHALL reject a single-file argument with an error directing the user to `opm instance build <file>` for instance files
+
+#### Scenario: config commands are in their own package
+
+- **WHEN** the `internal/cmd/config/` directory is inspected
+- **THEN** it contains all `config` sub-command implementations (`init`, `vet`)
+
+#### Scenario: instance commands are in their own package
+
+- **WHEN** the `internal/cmd/instance/` directory is inspected
+- **THEN** it SHALL contain all `instance` sub-command implementations: `vet`, `build`, `apply`, `diff`, `status`, `tree`, `events`, `delete`, `list`
+- **AND** the `instance build` subcommand SHALL accept either an instance `.cue` file or a module-package directory as its positional argument
+- **AND** when the argument is a directory the subcommand SHALL delegate to the same module-synthesis path used by `opm module build`
+
+#### Scenario: operator commands are in their own package
+
+- **WHEN** the `internal/cmd/operator/` directory is inspected
+- **THEN** it SHALL contain the `operator` sub-command implementations: `install`, `uninstall`
+- **AND** the commands SHALL be thin cobra wiring that delegates all behavior to `internal/operator/`
+
+## ADDED Requirements
+
+### Requirement: Operator command group registered at root level
+
+The root command SHALL register `opm operator` as a top-level command group via `cmdoperator.NewOperatorCmd(&cfg)`, following the same `GlobalConfig` dependency-injection pattern as the `module`, `instance`, and `config` groups. The group is noun-first (enhancement 0006 D32): there are no `opm install` or `opm uninstall` verb groups at root level.
+
+#### Scenario: Root command registers operator group
+
+- **WHEN** `internal/cmd/root.go` is inspected
+- **THEN** it SHALL contain `rootCmd.AddCommand(cmdoperator.NewOperatorCmd(&cfg))`
+- **AND** the root command SHALL NOT register `install` or `uninstall` as top-level commands

--- a/openspec/changes/archive/2026-07-03-cli-operator-install-command/specs/operator-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-07-03-cli-operator-install-command/specs/operator-lifecycle/spec.md
@@ -1,0 +1,127 @@
+# operator-lifecycle (delta)
+
+Operator lifecycle surface: `opm operator install` / `opm operator uninstall`, the embedded pinned operator manifest, readiness waits, uninstall safety, and the CLI's server-side-apply field-manager identity. Slice B2 of enhancement 0006 (D5, D23, D32–D35).
+
+## ADDED Requirements
+
+### Requirement: Full operator install from the embedded manifest
+
+`opm operator install` SHALL server-side-apply every document of the embedded operator manifest (`dist/install.yaml` of the pinned opm-operator release) with field manager `opm-cli`, ordered ascending by the resource weights of `pkg/resourceorder` (CRDs before Namespace before RBAC before Deployment). The command SHALL then wait, bounded by `--timeout` (default 5m), for every applied CRD to reach the `Established=True` condition and for the operator Deployment to complete its rollout, and SHALL exit non-zero with an actionable error if the timeout elapses first.
+
+#### Scenario: Install onto an empty cluster
+
+- **WHEN** `opm operator install` is run against a cluster with no OPM components
+- **THEN** all manifest documents are applied via SSA with field manager `opm-cli`
+- **AND** the command reports a per-resource status line (created/configured/unchanged) for each document
+- **AND** the command waits until the CRDs are `Established` and the operator Deployment rollout completes, then exits zero
+
+#### Scenario: Install is idempotent
+
+- **WHEN** `opm operator install` is run a second time with no cluster-side changes in between
+- **THEN** every document reports `unchanged` and the command exits zero
+
+#### Scenario: Readiness timeout
+
+- **WHEN** the operator Deployment cannot become ready within `--timeout`
+- **THEN** the command exits non-zero with an error naming the resource still unready and the elapsed timeout
+
+### Requirement: CRDs-only install via `--crds-only`
+
+`opm operator install --crds-only` SHALL apply only the `CustomResourceDefinition` documents filtered from the same embedded manifest, and SHALL wait only for the `Established=True` condition on those CRDs. No Namespace, RBAC, Deployment, or Service objects are created.
+
+#### Scenario: Solo-cluster CRD install
+
+- **WHEN** `opm operator install --crds-only` is run against an empty cluster
+- **THEN** exactly the manifest's `CustomResourceDefinition` documents are applied
+- **AND** the command waits for each to report `Established=True` and exits zero
+- **AND** no other kinds from the manifest exist on the cluster afterwards
+
+### Requirement: Single embedded artifact with a pinned version
+
+The CLI SHALL embed exactly one operator artifact — the pinned opm-operator release's `dist/install.yaml` — and SHALL derive every install/uninstall plan (full set, CRD subset, uninstall set) by filtering that one parsed artifact. The pinned release tag SHALL be recorded in a single Go constant adjacent to the embed directive, and a `task operator:sync VERSION=<tag>` task SHALL refresh both the embedded file and the constant from the corresponding opm-operator GitHub release asset.
+
+#### Scenario: CRD subset cannot drift from the full install
+
+- **WHEN** the source tree is inspected
+- **THEN** `dist/install.yaml` is the only embedded operator manifest (no separately embedded CRD files)
+- **AND** the CRDs-only plan is produced by filtering the parsed manifest for `kind: CustomResourceDefinition`
+
+#### Scenario: Pin refresh is a single reviewable diff
+
+- **WHEN** `task operator:sync VERSION=v1.0.0-alpha.3` is run
+- **THEN** the embedded `install.yaml` is replaced with that release's asset and the pin constant is rewritten to `v1.0.0-alpha.3`, with no other source changes
+
+### Requirement: `--version` fetches the release asset instead of the embed
+
+`opm operator install --version <tag>` SHALL fetch `install.yaml` from the opm-operator GitHub release `<tag>` over HTTPS and feed it through the same parse/plan/apply path as the embedded artifact. Fetch failures SHALL produce a clear error naming the tag and URL; no checksum or signature verification is performed at this stage (0006/D35). The command output SHALL name which version was installed and whether it came from the embed or a fetch.
+
+#### Scenario: Fetching a valid tag
+
+- **WHEN** `opm operator install --version v1.0.0-alpha.1` is run with network access
+- **THEN** the manifest is downloaded from that release's `install.yaml` asset and applied
+- **AND** the output states the installed version and its fetched origin
+
+#### Scenario: Fetching a missing tag
+
+- **WHEN** `opm operator install --version v9.9.9` is run and the release or asset does not exist
+- **THEN** the command exits non-zero with an error naming the tag and the attempted URL, and applies nothing
+
+### Requirement: Opt-in RBAC emission via `--rbac`
+
+`opm operator install --rbac` SHALL additionally create a ClusterRole `opm-cli-user` granting full verbs on `moduleinstances`, `get/patch/update` on `moduleinstances/status`, and `get/list` on `platforms`. When `--user <U>` or `--group <G>` is supplied alongside `--rbac`, the command SHALL also create a ClusterRoleBinding binding that subject to the role. Without `--rbac`, no RBAC objects beyond the manifest's own are created. `--user`/`--group` without `--rbac` SHALL be rejected as a flag-validation error before any cluster interaction.
+
+#### Scenario: RBAC off by default
+
+- **WHEN** `opm operator install --crds-only` is run
+- **THEN** no `opm-cli-user` ClusterRole or ClusterRoleBinding is created
+
+#### Scenario: Role plus binding for a user
+
+- **WHEN** `opm operator install --crds-only --rbac --user alice` is run
+- **THEN** the `opm-cli-user` ClusterRole and a ClusterRoleBinding for user `alice` are applied with field manager `opm-cli`
+
+#### Scenario: Subject flags require --rbac
+
+- **WHEN** `opm operator install --user alice` is run without `--rbac`
+- **THEN** the command fails flag validation with an error stating `--user`/`--group` require `--rbac`, before contacting the cluster
+
+### Requirement: Uninstall preserves CRDs and the Namespace
+
+`opm operator uninstall` SHALL delete the embedded manifest's documents except every `CustomResourceDefinition` and the `Namespace`, in descending resource-weight order. CRD removal remains a deliberate manual `kubectl delete crd`. The command SHALL NOT wait for deletion to complete (fire-and-report).
+
+#### Scenario: Uninstall after a full install
+
+- **WHEN** `opm operator uninstall` is run on a cluster with no `ModuleInstance` resources
+- **THEN** the operator Deployment, Service, RBAC objects, and ServiceAccount are deleted
+- **AND** the three OPM CRDs and the operator Namespace still exist afterwards
+
+### Requirement: Uninstall refuses while operator cleanup finalizers are armed
+
+Before deleting anything, `opm operator uninstall` SHALL list `ModuleInstance` resources cluster-wide; if any carries the `opmodel.dev/cleanup` finalizer, the command SHALL refuse (exit non-zero) and name each such instance as `namespace/name`. With `--remove-finalizers`, the command SHALL remove exactly the `opmodel.dev/cleanup` finalizer (leaving all other finalizers intact) from every such instance, state that the instances and their workloads are now orphaned, and then proceed. If the cluster-wide list fails (including RBAC denial), the command SHALL fail closed without deleting anything.
+
+#### Scenario: Refusal names the armed instances
+
+- **WHEN** `opm operator uninstall` is run while `default/jellyfin` carries the `opmodel.dev/cleanup` finalizer
+- **THEN** the command exits non-zero without deleting anything
+- **AND** the error names `default/jellyfin` and points at `--remove-finalizers` and its orphaning consequence
+
+#### Scenario: Override strips only the operator's finalizer
+
+- **WHEN** `opm operator uninstall --remove-finalizers` is run while an instance carries both `opmodel.dev/cleanup` and a foreign finalizer
+- **THEN** `opmodel.dev/cleanup` is removed from the instance, the foreign finalizer remains
+- **AND** the command states the orphaning consequence and proceeds with the uninstall
+
+#### Scenario: List failure fails closed
+
+- **WHEN** the uninstalling user lacks permission to list `moduleinstances` cluster-wide
+- **THEN** the command exits non-zero without deleting anything, mapping the RBAC error to the standard permission-denied exit code
+
+### Requirement: All CLI server-side-apply writes use field manager `opm-cli`
+
+Every server-side-apply write the CLI performs — instance/module applies and operator installs alike — SHALL use the field manager `opm-cli`. The former manager name `opm` is retired; ownership of resources previously applied under `opm` transfers on their next apply via the existing forced-conflicts behavior, with no user-visible change.
+
+#### Scenario: One manager identity across the CLI
+
+- **WHEN** any resource is applied by any CLI command after this change
+- **THEN** its `managedFields` attribute the CLI's fields to manager `opm-cli`
+- **AND** no CLI code path applies with manager `opm`

--- a/openspec/changes/archive/2026-07-03-cli-operator-install-command/tasks.md
+++ b/openspec/changes/archive/2026-07-03-cli-operator-install-command/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: cli-operator-install-command
+
+## 1. Field-manager rename (lands first — design decision 8)
+
+- [x] 1.1 Rename `fieldManagerName` from `opm` to `opm-cli` in `internal/kubernetes/labels.go`; sweep tests asserting the old value; run `go test ./internal/kubernetes/...`
+
+## 2. Manifest engine (`internal/operator`, pure — no cluster)
+
+- [x] 2.1 Add `internal/operator/manifest.go`: `go:embed` of the pinned `dist/install.yaml` + `PinnedOperatorVersion` constant, and multi-doc YAML parse to `[]*unstructured.Unstructured` via `k8s.io/apimachinery/pkg/util/yaml`; unit tests parse the real embedded artifact (16 docs, expected kinds)
+- [x] 2.2 Add plan functions: install plan (all docs, ascending `pkg/resourceorder` weight), CRDs-only plan (`kind == CustomResourceDefinition`), uninstall plan (all minus CRDs minus Namespace, descending weight); table-driven unit tests including the never-delete-CRDs/Namespace property
+- [x] 2.3 Add `task operator:sync VERSION=<tag>` to `Taskfile.yml` (download release asset, replace embed, rewrite pin constant); run it against `v1.0.0-alpha.2` to seed the embedded artifact
+- [x] 2.4 Add `internal/operator/fetch.go`: `--version` release-asset fetch over HTTPS (bounded timeout, error naming tag + URL on failure); unit test the URL construction and error shaping with a stub server
+
+## 3. Apply/wait primitives (`internal/kubernetes` + `internal/operator`)
+
+- [x] 3.1 Export a single-resource SSA helper from `internal/kubernetes/apply.go` (promote `applyResource`; `Apply` delegates to it — design decision 2); run existing apply tests unchanged
+- [x] 3.2 Add bounded readiness wait in `internal/operator/wait.go`: poll loop (2s interval, `--timeout` bound, context-cancellable) over per-object predicates — CRD `Established=True` (new check) and Deployment rollout via `kubernetes.EvaluateHealth`; unit test predicates against fixture objects, wait loop against a fake that flips ready
+
+## 4. `opm operator install`
+
+- [x] 4.1 Add `internal/operator/install.go`: run a plan through the SSA helper with per-resource status lines, then the readiness wait; wire `--crds-only`, `--version`, `--timeout`
+- [x] 4.2 Add `--rbac [--user|--group]`: build `opm-cli-user` ClusterRole (+ ClusterRoleBinding when a subject is given) as unstructured objects appended to the plan; flag-validation error for `--user`/`--group` without `--rbac`; unit test object shapes and flag validation
+- [x] 4.3 Add `internal/cmd/operator/` (group + `install.go` cobra wiring, thin per cmd-structure delta) and register `cmdoperator.NewOperatorCmd(&cfg)` in `internal/cmd/root.go`
+
+## 5. `opm operator uninstall`
+
+- [x] 5.1 Add finalizer guard in `internal/operator/uninstall.go`: cluster-wide `moduleinstances` list via the dynamic client (fail closed on list error), refusal naming each `namespace/name` carrying `opmodel.dev/cleanup`; `--remove-finalizers` strips exactly that finalizer via JSON patch and states the orphaning consequence; unit test guard logic against fake dynamic client
+- [x] 5.2 Execute the uninstall plan (descending weight, fire-and-report) and add `internal/cmd/operator/uninstall.go` wiring
+
+## 6. Verification and docs
+
+- [x] 6.1 e2e against kind (`task cluster:create`): install → idempotent re-install → `--crds-only` on a fresh cluster → uninstall with an armed finalizer (refusal, then `--remove-finalizers`) → CRDs/Namespace survive; first confirm the pinned operator image is pullable/preloadable in the e2e environment, else assert through CRD `Established` + Deployment created (design risk 1)
+- [x] 6.2 Update `README.md` command groups; run `task fmt`, `task lint`, `task test`

--- a/openspec/changes/cli-cr-inventory-backend/.openspec.yaml
+++ b/openspec/changes/cli-cr-inventory-backend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/cli-cr-inventory-backend/design.md
+++ b/openspec/changes/cli-cr-inventory-backend/design.md
@@ -1,0 +1,92 @@
+# Design: cli-cr-inventory-backend
+
+Enhancement 0006, slice C1. Decision numbers `DN` below are local to this change; enhancement decisions are cited as `0006/DN`.
+
+## Context
+
+Today the CLI persists "what did I deploy" in a proprietary inventory Secret (`internal/inventory`: `secret.go` marshaling, `crud.go` get/write, `list.go` label-selector listing, `discover.go` per-entry GETs), while the operator persists the same fact in `ModuleInstance.status.inventory`. The apply flow (`internal/workflow/apply/apply.go`) computes digests, loads the previous Secret, computes the stale set (`pkg/inventory` + `internal/inventory/stale.go`), SSA-applies with field manager `opm-cli`, prunes, and writes the Secret back. Slices A2 (module rename), A4 (`spec.owner` marker CRD), and B2 (`opm operator install/uninstall`, embedded pinned CRD, `opm-cli` manager rename) have shipped; A6 (`Platform.status.operatorVersion`) is implemented on an opm-operator branch but unreleased.
+
+This slice replaces the Secret with the `ModuleInstance` CR as the single inventory store, adds the pre-apply gate battery, performs the one-time migration, and bumps CUE to v0.17.1. Render still goes through the CLI's current `pkg/render` pipeline — kernel adoption is slice C2; handoff is C3.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `apply`/`delete`/`status`/`list`/`diff` read/write the `ModuleInstance` CR; the Secret backend is deleted.
+- The CLI writes exactly the 0006/D2 status subset (as amended by 0006/D25 — no conditions) and the 0006/D3 `spec.owner: cli` marker; `spec.module` is always the canonical declared reference (0006/D6 write-side, 0006/D37).
+- Pre-apply gates: missing-CRD hint, CRD field floor, operator-version ceiling, status-RBAC pre-flight (0006/D24, D27, D23b, D33).
+- One-time Secret→CR migration, delete-Secret-after-success, no deprecation window (0006/D8, D14).
+- `cuelang.org/go` v0.16.1 → v0.17.1 (0006/D36), with the `cue.mod/local-module.cue` loader behavior verified and surfaced as render provenance (0006/D37, OQ17).
+
+**Non-Goals:**
+
+- Kernel adoption, platform resolution, `--platform` flag, `#ModuleInstance` synthesis retirement (C2).
+- `opm instance handoff`, the thin-editor apply mode for operator-owned CRs, delete symmetry (C3) — this slice ships refusals at the branch point C3 will extend.
+- Any operator-side change (A6 lands in opm-operator).
+- Prune-behavior changes: stale-set/rename-safety/existence-check logic is ported as-is (0006/D31); reconciling the CLI/operator stale-set base relation is 0006/OQ15, open.
+
+## Decisions
+
+### D1: The CR backend lives in `internal/inventory`, rewritten in place
+
+`internal/inventory` keeps its name and its consumers; the Secret files (`secret.go`, `crud.go`, `list.go`) are replaced by a CR-backed store (`cr.go`, `store.go` or equivalent). The `ModuleInstance` GVR, kind, and field constants move here as the single source; `internal/operator/uninstall.go`'s private `moduleInstanceGVR` copy is replaced by an import. Per repo rule ("update existing packages over new abstractions") and 0006/D13 (no `opm-operator` Go import), the CR is handled as `unstructured` via the dynamic client. `pkg/inventory` (entry identity, stale set, digest) and `internal/inventory/stale.go` (rename safety, `PreApplyExistenceCheck`, prune) are untouched in semantics. `discover.go`'s per-entry live-resource discovery is retained (it is entry-driven, not Secret-driven) with its input re-typed to the CR-backed record.
+
+*Alternative — a new `internal/instancecr` package:* rejected; it would leave `internal/inventory` a stub and force every consumer to re-import for no boundary gain.
+
+### D2: Explicit wire-shape mapping, never struct-tag marshaling
+
+The CRD serializes `InventoryEntry.Version` as `v` (`opm-operator/api/v1alpha1/common_types.go`); the CLI's `pkg/inventory.InventoryEntry` has its own JSON tags. Conversion between `pkg/inventory` types and the CR's `status.inventory` is done by explicit map-building functions that target the CRD's OpenAPI shape (`group`, `kind`, `namespace`, `name`, `v`, `component`; `inventory.revision/digest/count/entries`), with round-trip unit tests. Marshaling Go structs by their tags into the unstructured object is forbidden — the CRD schema, not the Go tags, anchors cross-actor shape parity (0006/D31).
+
+### D3: Write mechanics — SSA for spec, SSA on the status subresource for status, guard-read first
+
+Every apply: (1) GET the CR (404 ⇒ new instance); (2) resolve the ownership mode (D4); (3) SSA-apply the spec document (create-or-update) with field manager `opm-cli`: `spec.owner: cli`, `spec.module` (canonical declared path/version — local applies included, 0006/D37), `spec.values` (the unified blob, 0006/D19), plus managed labels and the provenance annotation (D7); (4) after resources are applied and pruned, SSA-apply the status subset on the **status subresource**: `inventory`, `instanceUUID`, `lastAppliedRenderDigest`, `lastAppliedSourceDigest`, `lastAppliedConfigDigest`, `lastAppliedAt` — never `conditions`, never `observedGeneration` (0006/D2/D25). `instanceUUID` is extracted from the rendered resources' `module-instance.opmodel.dev/uuid` label (first non-empty — the operator's `extractInstanceUUID` mechanism; deterministic UUIDv5 computed in core CUE), omitted if absent. Dry-run applies touch neither the CR nor the gates that exist to protect writes (D5 note).
+
+### D4: One ownership branch point
+
+A single mode-resolution function (e.g. `ResolveOwnership(cr)`) maps `spec.owner` to a mode: absent CR or `owner: cli` (or empty — a CR the CLI itself wrote always carries `cli` explicitly) ⇒ CLI-executor mode; `owner: operator` ⇒ refusal in this slice. `apply` refuses with "instance is operator-managed (`spec.owner: operator`); the CLI does not edit operator-owned instances yet". `delete` refuses with the kubectl hint (`kubectl delete moduleinstance <name>` — the operator's cleanup finalizer prunes the workloads). C3 replaces the refusal arm with the 0006/D18 thin-editor mode without touching callers. This function replaces the record-based `EnsureCLIMutable`/`createdBy` guard.
+
+### D5: Gate battery — order, mechanics, and the dev-build ceiling rule
+
+On real (non-dry-run) applies, before any resource is written, in order:
+
+1. **CRD present** — GET the `moduleinstances.opmodel.dev` CRD (apiextensions). NotFound ⇒ `ModuleInstance CRD not found — run 'opm operator install --crds-only'` (0006/D27/D32).
+2. **CRD field floor** — the served storage version's schema must contain `spec.owner` and `status.inventory` properties. Missing ⇒ "ModuleInstance CRD is missing required fields — run 'opm operator install --crds-only'" (0006/D24 floor; guards the API server silently pruning `spec.owner`).
+3. **Operator-version ceiling** — GET the singleton cluster `Platform`; if the CR or `status.operatorVersion` is absent ⇒ solo cluster, skip (0006/D24 semantics; requires A6-carrying operator for the field to exist). Present and semver-greater than the CLI's version ⇒ refuse ("your CLI is older than the cluster operator — upgrade the CLI"). **Dev builds** (version not valid semver, e.g. `dev`) skip the ceiling with a warning — a dev CLI is presumed current, and refusing would make every from-source build unusable against real clusters.
+4. **Ownership** (D4).
+5. **Status-RBAC pre-flight** — `SelfSubjectAccessReview` for `patch moduleinstances/status` in the target namespace; denial aborts before any apply with the 0006/D23 remedial hint. CLI-executor mode only.
+6. **Existing `PreApplyExistenceCheck`** (first-ever apply only), unchanged.
+
+Gates 1–3 are read-only cluster probes; RBAC failures reading the Platform in gate 3 degrade to skip-with-warning rather than hard failure (a namespace-scoped user must still be able to apply — 0006/D17 accessibility).
+
+### D6: Migration — read Secret once, write CR, delete Secret only after status write succeeds
+
+On apply, when the CR is absent but a legacy inventory Secret exists (direct name + label fallback, today's lookup): build the CR from the Secret record (entries/revision/digest/count into `status.inventory`, record UUID into `instanceUUID`, timestamps into `lastAppliedAt`; spec comes from the *current* apply's module/values), proceed with the normal apply, and delete the Secret **only after** the CR status write succeeds. A failure anywhere leaves the Secret intact and the release discoverable by a re-run. `status`/`delete`/`list`/`diff` never read Secrets (0006/D8 as amended by D14 — no fallback window); an instance tracked only by a Secret reappears on its next apply.
+
+### D7: Render provenance annotation — written here, consumed by C3's handoff as a fail-closed pre-gate (resolves 0006/OQ17)
+
+The loader records render provenance; when the module bytes did not come from pure registry resolution — the main module is a local directory, **or** the main module's `cue.mod/local-module.cue` contains any local-path `replaceWith` (conservative: any replacement marks the render, since replaced dependencies also change bytes) — the CLI stamps `module-instance.opmodel.dev/source: local` on the CR in the spec apply. When a later apply resolves fully from registries, the annotation is omitted from the applied document and SSA field ownership removes it. The annotation **only ever blocks**: C3's handoff refuses while it is present ("last apply used a local module — publish and re-apply, then hand off"), and the authoritative backstop is C3's verification render, which MUST bypass `local-module.cue` and resolve `spec.module` strictly from the registry — otherwise a local replacement would make 0006/D7.4's digest check self-consistent and meaningless. Stripping the annotation by hand grants nothing (the strict-registry digest gate stands behind it); a checkout byte-identical to the published module clears naturally via the re-apply the error prescribes. The C3-side requirements are recorded in enhancement 0006 with this OQ17 resolution; this slice ships the write side plus detection.
+
+### D8: `instance list` — native CR list (0006/D29)
+
+`ListInventories` is replaced by a namespace-scoped `ModuleInstance` list; a new `--all-namespaces` flag issues a cluster-wide list. Insufficient RBAC surfaces as a clear, actionable error (no label fallback, no silent narrowing). Health evaluation (`internal/workflow/query/list.go`) keeps its per-entry discovery, fed from the CR record. `--instance-id` selectors resolve by listing and matching `status.instanceUUID`.
+
+### D9: CUE v0.17.1 in the same slice (0006/D36)
+
+`go.mod` bumps `cuelang.org/go` v0.16.1 → v0.17.1 first (trial-verified 2026-07-16: zero code changes, unit suite green). An integration fixture with a `cue.mod/local-module.cue` replacement verifies the loader honors `replaceWith` end-to-end — the same mechanism D7's detection relies on. If the loader's own resolution wiring bypasses the local module file, that is fixed here (it must go through the SDK's standard module resolution).
+
+## Risks / Trade-offs
+
+- **A6 is unreleased** → the ceiling gate cannot be exercised e2e until an operator release carries `Platform.status.operatorVersion` and the B2 pin is bumped (`task operator:sync`). → Unit-test the gate against fake dynamic objects now; land the e2e once the release exists. Absence semantics (skip) mean the gate is safe-but-inert against today's operator — which is exactly the 0006/D24 caveat, not a regression.
+- **CRD schema introspection (floor gate) is structurally fiddly** → keep it to two property-path existence checks on the served storage version; unit-test against the embedded B2 CRD manifest (which already contains both fields).
+- **SSA removal semantics for the provenance annotation** (annotation must disappear when omitted) → covered by an envtest-style unit test; if granular annotation ownership proves unreliable, fall back to explicitly writing `source: registry`/removing via JSON patch — same contract, different mechanism.
+- **Migration mid-failure** → delete-after-success ordering leaves the Secret authoritative until the CR status write lands; re-running apply is idempotent (CR now exists, Secret still present ⇒ migration retries the delete only).
+- **Version-compare edge cases (ceiling gate)** → dev builds skip-with-warning (D5); pre-release semver compares per semver 2.0.0 via a vetted library.
+- **Old CLI + migrated instance** → after migration the Secret is gone; an older CLI sees nothing. Accepted explicitly under 0006/D14 (single user, no external consumers).
+
+## Migration Plan
+
+Single release, no flags, no window: ship, re-apply live instances once (each apply migrates its own Secret), done. Rollback = previous CLI binary, which still reads any not-yet-migrated Secrets; already-migrated instances would need a manual re-apply under the old binary to recreate Secrets (accepted, D14). Docs: `apply`/`delete`/`list`/`status` reference pages and the QUICKSTART gain the CRD-prerequisite note and the `opm operator install --crds-only` first-run step.
+
+## Open Questions
+
+None blocking implementation. Landing-order note: the ceiling gate's e2e and the embedded-pin bump wait on the A6 opm-operator release; everything else in this slice is independent of it.

--- a/openspec/changes/cli-cr-inventory-backend/proposal.md
+++ b/openspec/changes/cli-cr-inventory-backend/proposal.md
@@ -1,0 +1,38 @@
+# Proposal: cli-cr-inventory-backend
+
+Enhancement 0006, slice C1. Implements D1, D2 (as amended by D25), D3 (consume), D6 (write-side), D8, D14, D23 (pre-flight half), D24, D27 (as respelled by D32), D33, D36, D37; leaves OQ17 resolved here at drafting time (see design.md).
+
+## Why
+
+The CLI records what it deployed in a proprietary inventory Secret while the operator records the same fact in `ModuleInstance.status.inventory` — two disjoint stores for one fact, which makes safe CLI↔operator handoff (enhancement 0006's goal) structurally impossible. This slice makes the `ModuleInstance` CR the single inventory store both actors share: the operator's prune set is `previous status.inventory − current render`, so once the CLI writes its deployed entries into the same field, the operator's first post-handoff reconcile sees a zero stale set.
+
+## What Changes
+
+- **The CLI writes a `ModuleInstance` CR instead of a Secret** on `opm instance apply` / `opm module apply` (D1): named after the instance, in the target namespace, handled as `unstructured` via the dynamic client (no `opm-operator` Go import — D13), SSA with field manager `opm-cli`. Spec: `owner: cli` (D3), canonical declared `module.path`/`module.version` — for local applies too, never a filesystem path (D6 write-side, D37) — and the unified values blob as `spec.values` (D19). Status (via the status subresource): `inventory`, `instanceUUID` (extracted from the rendered `module-instance.opmodel.dev/uuid` label, same mechanism as the operator), and the `lastApplied*` digest/timestamp set — **no `status.conditions`** (D2/D25).
+- **`apply`/`delete`/`status`/`list`/`diff` are rewired** to read/write the CR. `instance list` becomes a native CR list; `--all-namespaces` is a cluster-wide CR list that fails with a clear RBAC error, no label fallback (D29).
+- **Pre-apply gates land on the apply path** (D33): missing-CRD fail-with-hint (`ModuleInstance CRD not found — run 'opm operator install --crds-only'`, D27/D32); CRD field-presence floor (`spec.owner` + `status.inventory` in the installed schema) and operator-version ceiling read from `Platform.status.operatorVersion`, absent ⇒ solo cluster, skipped (D24); `SelfSubjectAccessReview` for `moduleinstances/status` before any resource is applied, CLI-owned path only (D23b).
+- **Ownership guard as one mode-resolution branch** (D3/D18): operator-owned instances are refused on `apply` and `delete` with actionable hints; D18's thin-editor apply mode and delete symmetry defer to slice C3, which replaces the refusal arm without touching callers.
+- **BREAKING: one-time Secret→CR migration, no deprecation window** (D8/D14): on apply, an existing Secret inventory with no CR is migrated (create CR, port record, delete Secret only after the status write succeeds); `status`/`delete`/`list` read CRs only — Secret-tracked instances become visible again on their next apply.
+- **Secret-specific code is deleted** (`internal/inventory/secret.go`, `crud.go`, `list.go`); the entry-identity/stale-set/digest/rename-safety/collision logic (`pkg/inventory`, `internal/inventory/stale.go`) is ported onto the CR flow as-is (D31), and per-entry live-resource discovery (`discover.go`) is re-homed, not removed.
+- **`cuelang.org/go` v0.16.1 → v0.17.1** (D36 — trial-verified 2026-07-16: zero code changes, unit suite green), including verifying the loader honors `cue.mod/local-module.cue` replacements (D37). Render still uses the CLI's current pipeline; kernel adoption is slice C2.
+
+## Capabilities
+
+### New Capabilities
+
+- `apply-preflight-gates`: the gate battery that runs before any resource is applied — CRD presence hint, CRD field-presence floor, operator-version ceiling, and the `moduleinstances/status` access pre-flight.
+- `secret-inventory-migration`: the one-time, delete-after-success Secret→CR migration performed on apply.
+
+### Modified Capabilities
+
+- `instance-inventory`: the persisted record envelope and CRUD move from a Secret to the `ModuleInstance` CR (`status.inventory` + CLI status subset + spec write); entry identity/digest semantics unchanged.
+- `inventory-ownership`: ownership derives from `spec.owner` on the CR instead of the record's `createdBy`; refusal semantics for operator-owned instances defined here.
+- `inventory-listing`: listing is a native `ModuleInstance` CR list (namespace-scoped by default, `--all-namespaces` cluster-wide, clear RBAC error) instead of a Secret label-selector list.
+- `resource-discovery`: per-entry live-resource discovery reads entries from the CR-backed inventory instead of the Secret record.
+
+## Impact
+
+- **Packages**: `internal/inventory` (Secret CRUD deleted; CR store added), `internal/workflow/apply`, `internal/workflow/query`, `internal/cmd/instance/{apply,delete,diff,list,status}.go`, `internal/cmd/module/apply.go`, `internal/kubernetes` (delete path's Secret-last ordering becomes CR-last), `internal/operator` (the hardcoded `moduleInstanceGVR` lifts to a shared home), `go.mod` (CUE bump).
+- **SemVer**: breaking (`feat!`) — the Secret inventory format is dropped without a window. Accepted under D14 (single user, no external consumers).
+- **Dependencies**: A2/A4/B2 shipped. **A6 gates landing, not drafting**: implemented on opm-operator branch `feat/platform-status-operator-version`, unmerged/unreleased as of 2026-07-16 — the ceiling gate's e2e needs an operator release carrying it plus a `task operator:sync` pin bump.
+- **Out of scope** (later slices): kernel adoption / platform resolution / `#ModuleInstance` synthesis retirement (C2), handoff + thin-editor mode (C3), operator-side changes (A6 lands in opm-operator).

--- a/openspec/changes/cli-cr-inventory-backend/specs/apply-preflight-gates/spec.md
+++ b/openspec/changes/cli-cr-inventory-backend/specs/apply-preflight-gates/spec.md
@@ -1,0 +1,84 @@
+# apply-preflight-gates
+
+## Purpose
+
+The gate battery that runs on the CLI's real (non-dry-run) apply path before any resource is written: CRD presence, CRD field-presence floor, operator-version ceiling, and the status-RBAC pre-flight. Enhancement 0006 D24/D27/D23/D33 — these gates give the `ModuleInstance` CRD its role as a hard prerequisite for CLI apply.
+
+## ADDED Requirements
+
+### Requirement: Missing-CRD gate with install hint
+
+Before applying any resource, the CLI SHALL verify the `moduleinstances.opmodel.dev` CustomResourceDefinition exists. When absent, apply SHALL fail with the one-line hint: `ModuleInstance CRD not found — run 'opm operator install --crds-only'`, and do nothing else.
+
+#### Scenario: CRD absent
+
+- **WHEN** `opm instance apply` runs against a cluster without the ModuleInstance CRD
+- **THEN** the command SHALL exit non-zero with the install hint
+- **AND** no resource SHALL have been applied
+
+### Requirement: CRD field-presence floor
+
+Before applying, the CLI SHALL verify the installed `ModuleInstance` CRD's served storage-version schema contains the `spec.owner` and `status.inventory` properties. When either is missing, apply SHALL refuse with: `ModuleInstance CRD is missing required fields — run 'opm operator install --crds-only'`.
+
+#### Scenario: Outdated CRD refused
+
+- **WHEN** the installed CRD schema lacks `spec.owner`
+- **THEN** apply SHALL exit non-zero with the missing-fields error before any resource is applied
+
+#### Scenario: Current CRD passes
+
+- **WHEN** the installed CRD schema contains both `spec.owner` and `status.inventory`
+- **THEN** the floor gate SHALL pass silently
+
+### Requirement: Operator-version ceiling
+
+Before applying, the CLI SHALL read the cluster-scoped singleton `Platform` and compare `status.operatorVersion` to its own version. If the Platform or the field is absent, the check SHALL be skipped (solo cluster semantics). If the operator version is semver-greater than the CLI version, apply SHALL refuse with an error telling the user to upgrade the CLI. If the CLI's own version is not valid semver (dev build), the check SHALL be skipped with a warning. If reading the Platform fails due to RBAC, the check SHALL be skipped with a warning (a namespace-scoped user must remain able to apply).
+
+#### Scenario: Solo cluster skips the ceiling
+
+- **WHEN** no `Platform` CR exists or `status.operatorVersion` is absent
+- **THEN** the ceiling check SHALL be skipped and apply SHALL proceed
+
+#### Scenario: Older CLI refused
+
+- **WHEN** `status.operatorVersion` is `1.2.0` and the CLI version is `1.1.0`
+- **THEN** apply SHALL exit non-zero with an upgrade-the-CLI error
+
+#### Scenario: Dev build skips with warning
+
+- **WHEN** the CLI version is `dev`
+- **THEN** the ceiling check SHALL be skipped and a warning SHALL be printed
+
+#### Scenario: Platform read denied degrades to warning
+
+- **WHEN** reading the `Platform` returns a forbidden error
+- **THEN** the ceiling check SHALL be skipped with a warning and apply SHALL proceed
+
+### Requirement: Status-RBAC pre-flight
+
+In CLI-executor mode, before applying any resource, the CLI SHALL issue a `SelfSubjectAccessReview` for `patch` on `moduleinstances/status` in the target namespace. On denial, apply SHALL abort with an actionable error explaining that inventory cannot be recorded and naming the remedies (grant `moduleinstances/status`, or `opm operator install --crds-only --rbac`). The pre-flight guarantees resources are never deployed without a recordable inventory.
+
+#### Scenario: Denied status access aborts before apply
+
+- **WHEN** the SSAR reports `patch moduleinstances/status` is denied
+- **THEN** apply SHALL exit non-zero before any resource is applied
+- **AND** the error SHALL name the `--rbac` remedy
+
+#### Scenario: Allowed status access proceeds silently
+
+- **WHEN** the SSAR reports the access is allowed
+- **THEN** apply SHALL proceed with no additional output
+
+### Requirement: Gate ordering and dry-run exemption
+
+The gates SHALL run in the order: CRD presence, CRD field floor, operator-version ceiling, ownership resolution, status-RBAC pre-flight, pre-apply existence check — all before the first resource write. Dry-run applies SHALL skip the gate battery (they write nothing the gates protect).
+
+#### Scenario: Gates precede all writes
+
+- **WHEN** any gate fails during `opm instance apply`
+- **THEN** zero resources SHALL have been created or modified in the cluster
+
+#### Scenario: Dry-run skips gates
+
+- **WHEN** `opm instance apply --dry-run` runs against a cluster without the ModuleInstance CRD
+- **THEN** the render SHALL be produced without the missing-CRD error

--- a/openspec/changes/cli-cr-inventory-backend/specs/instance-inventory/spec.md
+++ b/openspec/changes/cli-cr-inventory-backend/specs/instance-inventory/spec.md
@@ -1,0 +1,156 @@
+# Delta: instance-inventory (cli-cr-inventory-backend)
+
+The persisted envelope and CRUD move from an inventory Secret to the `ModuleInstance` CR. Entry identity, K8s identity, entry construction, ownership-only inventory semantics, and deterministic digest requirements are unchanged.
+
+## ADDED Requirements
+
+### Requirement: ModuleInstance CR is the inventory store
+
+The CLI SHALL persist instance inventory in a `ModuleInstance` custom resource (`opmodel.dev/v1alpha1`, resource `moduleinstances`) named after the instance, in the instance's namespace, handled as `unstructured` via the dynamic client. The CLI MUST NOT import `opm-operator` Go packages. The `ModuleInstance` GVR and related constants SHALL be defined once in `internal/inventory` and consumed by all CLI packages that reference the CR (including `internal/operator`).
+
+#### Scenario: Apply creates the CR
+
+- **WHEN** `opm instance apply` succeeds for instance `podinfo` in namespace `demo` and no `ModuleInstance` exists
+- **THEN** a `ModuleInstance` named `podinfo` SHALL exist in `demo` with the CLI's spec and status subset
+
+#### Scenario: No inventory Secret is written
+
+- **WHEN** any apply completes
+- **THEN** no `opm.<name>.<id>` inventory Secret SHALL be created or updated
+
+### Requirement: CLI writes a strict status subset via the status subresource
+
+After resources are applied and pruned, the CLI SHALL write, via the status subresource with field manager `opm-cli`: `status.inventory` (revision, digest, count, entries), `status.instanceUUID`, `status.lastAppliedRenderDigest`, `status.lastAppliedSourceDigest`, `status.lastAppliedConfigDigest`, and `status.lastAppliedAt`. The CLI MUST NOT write `status.conditions`, `status.observedGeneration`, `status.lastAttempted*`, `status.failureCounters`, `status.history`, or `status.nextRetryAt`.
+
+#### Scenario: Status subset after successful apply
+
+- **WHEN** an apply deploys 3 resources successfully
+- **THEN** `status.inventory.count` SHALL be 3 and `status.lastAppliedAt` SHALL be set
+- **AND** `status.conditions` SHALL NOT be present in the CLI's applied status document
+
+#### Scenario: Revision increments across applies
+
+- **WHEN** a second apply succeeds for an instance whose `status.inventory.revision` was 1
+- **THEN** the written `status.inventory.revision` SHALL be 2
+
+### Requirement: Spec write contents
+
+On apply in CLI-executor mode, the CLI SHALL server-side-apply the CR spec with field manager `opm-cli`, containing: `spec.owner: cli`, `spec.module.path` and `spec.module.version` set to the module's canonical declared path and version (for local-directory and locally-replaced module resolution as well — the CR MUST NOT contain a filesystem path), and `spec.values` set to the single unified values blob that the render consumed.
+
+#### Scenario: Local-path apply writes the declared reference
+
+- **WHEN** applying from a local module directory whose `module.cue` declares path `opmodel.dev/modules/podinfo@v0` and version `v0.1.0`
+- **THEN** `spec.module.path` SHALL be `opmodel.dev/modules/podinfo@v0` and `spec.module.version` SHALL be `v0.1.0`
+
+#### Scenario: Values are the unified blob
+
+- **WHEN** applying with multiple `--values` files
+- **THEN** `spec.values` SHALL contain the single unified result the render consumed, not the individual layers
+
+### Requirement: Entry wire shape targets the CRD schema
+
+Conversion between the CLI's `InventoryEntry` type and the CR's `status.inventory.entries[]` SHALL be performed by explicit mapping functions that produce/consume the CRD's field names (`group`, `kind`, `namespace`, `name`, `v`, `component`), independent of the Go struct's own JSON tags. The mapping SHALL round-trip losslessly.
+
+#### Scenario: Version serializes as `v`
+
+- **WHEN** an entry with Version `v1` is written to the CR
+- **THEN** the entry object in `status.inventory.entries[]` SHALL carry the key `v` with value `v1`
+
+#### Scenario: Round-trip preserves the entry set
+
+- **WHEN** an entry list is written to a CR and read back
+- **THEN** the resulting entries SHALL equal the originals
+
+### Requirement: instanceUUID is extracted from the render
+
+The CLI SHALL populate `status.instanceUUID` from the rendered resources' `module-instance.opmodel.dev/uuid` label (first non-empty value). If no rendered resource carries the label, the field SHALL be omitted. The CLI MUST NOT generate the UUID itself.
+
+#### Scenario: UUID extracted from rendered labels
+
+- **WHEN** rendered resources carry `module-instance.opmodel.dev/uuid: 7c9e6679-7425-40de-944b-e07fc1f90ae7`
+- **THEN** `status.instanceUUID` SHALL be `7c9e6679-7425-40de-944b-e07fc1f90ae7`
+
+### Requirement: Render provenance annotation
+
+When the applied render's module bytes did not come from pure registry resolution — the main module is a local directory, or the main module's `cue.mod/local-module.cue` contains any local-path `replaceWith` — the CLI SHALL include the annotation `module-instance.opmodel.dev/source: local` in its spec apply. When a later apply resolves fully from registries, the CLI SHALL omit the annotation so server-side apply removes it. The annotation is a fail-closed signal for the handoff pre-gate (slice C3); no CLI gate in this slice SHALL read it as an authority.
+
+#### Scenario: Local render stamps the annotation
+
+- **WHEN** an apply renders from a local module directory
+- **THEN** the CR SHALL carry `module-instance.opmodel.dev/source: local`
+
+#### Scenario: Replacement in effect stamps the annotation
+
+- **WHEN** an apply's main module has a `cue.mod/local-module.cue` with a local-path `replaceWith`
+- **THEN** the CR SHALL carry `module-instance.opmodel.dev/source: local`
+
+#### Scenario: Registry apply clears the annotation
+
+- **WHEN** an instance carrying the annotation is re-applied with fully registry-resolved modules
+- **THEN** the annotation SHALL no longer be present on the CR
+
+### Requirement: CR CRUD semantics
+
+Reading inventory SHALL be a direct GET of the `ModuleInstance` by name and namespace, with NotFound returned as "no inventory" (first-apply). `--instance-id` selectors SHALL resolve by listing `ModuleInstance` CRs and matching `status.instanceUUID`. On `instance delete`, the CLI SHALL delete owned resources first (existing reverse-weight prune semantics) and delete the CR last; CR deletion SHALL treat NotFound as success.
+
+#### Scenario: First apply finds no inventory
+
+- **WHEN** `opm instance apply` runs and no `ModuleInstance` exists for the name
+- **THEN** the apply SHALL proceed as a first-time apply with an empty previous inventory
+
+#### Scenario: Delete removes the CR last
+
+- **WHEN** `opm instance delete` succeeds
+- **THEN** every tracked resource SHALL be deleted before the `ModuleInstance` CR itself
+
+## REMOVED Requirements
+
+### Requirement: Inventory Secret name convention
+
+**Reason**: The inventory Secret is replaced by the `ModuleInstance` CR (enhancement 0006 D1); there is no Secret to name.
+**Migration**: The CR is named after the instance in the instance namespace; the one-time migration (see `secret-inventory-migration`) ports existing Secrets.
+
+### Requirement: Inventory Secret labels
+
+**Reason**: No inventory Secret exists; instance identity labels live on the CR's rendered resources and metadata.
+**Migration**: None required — CR lookup is by name/namespace, not label selector.
+
+### Requirement: Inventory Secret serialization roundtrip
+
+**Reason**: The JSON-in-Secret envelope (`MarshalToSecret`/`UnmarshalFromSecret`) is deleted with the Secret backend.
+**Migration**: The CRD's OpenAPI schema anchors the persisted shape; explicit mapping functions replace envelope marshaling. Unmarshaling survives only inside the one-time migration path.
+
+### Requirement: Inventory Secret CRUD operations
+
+**Reason**: `GetInventory`/`WriteInventory`/`DeleteInventory` over Secrets are replaced by CR CRUD (see ADDED "CR CRUD semantics").
+**Migration**: One-time Secret→CR migration on apply; no Secret reads elsewhere.
+
+### Requirement: Inventory labels remain unchanged when provenance is added
+
+**Reason**: Obsolete with the Secret label contract removed.
+**Migration**: None.
+
+### Requirement: Inventory metadata enables future CRD migration
+
+**Reason**: Fulfilled — this change *is* the CRD migration the `kind`/`apiVersion` fields anticipated.
+**Migration**: The migration path consumes those fields one final time when porting Secrets.
+
+### Requirement: Persisted instance inventory record preserves instance and module metadata
+
+**Reason**: The record envelope is gone; the CR carries instance identity in `metadata`, module identity in `spec.module`, and the UUID in `status.instanceUUID`.
+**Migration**: The one-time migration maps `instanceMetadata.uuid` → `status.instanceUUID`; module identity comes from the current apply's resolved module.
+
+### Requirement: Persisted instance inventory record stores creator provenance at the top level
+
+**Reason**: Creator provenance (`createdBy`) is replaced by the CR's `spec.owner` marker (see `inventory-ownership` delta).
+**Migration**: Migrated CRs are written with `spec.owner: cli`.
+
+### Requirement: Instance metadata data key structure
+
+**Reason**: The `instanceMetadata` envelope object is deleted with the record shape.
+**Migration**: Instance name/namespace live on the CR's `metadata`; the UUID in `status.instanceUUID`.
+
+### Requirement: Module metadata data key structure
+
+**Reason**: The `moduleMetadata` envelope object is deleted with the record shape.
+**Migration**: Module path/version live in `spec.module`.

--- a/openspec/changes/cli-cr-inventory-backend/specs/inventory-listing/spec.md
+++ b/openspec/changes/cli-cr-inventory-backend/specs/inventory-listing/spec.md
@@ -1,0 +1,46 @@
+# Delta: inventory-listing (cli-cr-inventory-backend)
+
+Listing moves from a Secret label-selector list to a native `ModuleInstance` CR list (enhancement 0006 D29).
+
+## ADDED Requirements
+
+### Requirement: Instance listing is a native ModuleInstance CR list
+
+`opm instance list` SHALL list `ModuleInstance` custom resources in the target namespace (resolved by the standard namespace precedence). Results SHALL be sorted alphabetically by instance name. A CR that cannot be interpreted (e.g. malformed status) SHALL be reported with a warning and skipped, without failing the listing.
+
+#### Scenario: List in a specific namespace
+
+- **WHEN** `opm instance list -n production` runs and 3 `ModuleInstance` CRs exist in `production`
+- **THEN** the command SHALL display those 3 instances sorted by name
+
+#### Scenario: Empty namespace lists nothing
+
+- **WHEN** `opm instance list` runs against a namespace with no `ModuleInstance` CRs
+- **THEN** the command SHALL succeed with an empty result
+
+### Requirement: Cluster-wide listing via --all-namespaces
+
+`opm instance list --all-namespaces` (shorthand `-A`) SHALL perform a cluster-wide `ModuleInstance` list. On insufficient RBAC (cross-namespace list denied), the command SHALL fail with a clear, actionable error naming the missing permission. It MUST NOT degrade to a partial or label-based listing.
+
+#### Scenario: Cluster-wide list
+
+- **WHEN** `opm instance list -A` runs with cluster-wide list permission
+- **THEN** instances from all namespaces SHALL be displayed with their namespaces
+
+#### Scenario: Insufficient RBAC fails clearly
+
+- **WHEN** `opm instance list -A` runs without cluster-wide `list` permission on `moduleinstances`
+- **THEN** the command SHALL exit non-zero with an error naming the required permission
+- **AND** SHALL NOT display a partial result
+
+## REMOVED Requirements
+
+### Requirement: ListInventories discovers all inventory Secrets in a namespace
+
+**Reason**: Inventory Secrets no longer exist (enhancement 0006 D1/D8); the `ModuleInstance` CRs are the inventory, so listing CRs *is* the listing.
+**Migration**: `opm instance list` lists `ModuleInstance` CRs (see ADDED requirements). Secret-tracked instances become visible after their one-time migration on next apply.
+
+### Requirement: ListInventories uses existing label constants
+
+**Reason**: Label-selector discovery of inventory Secrets is deleted with the Secret backend.
+**Migration**: None — CR listing needs no label selector.

--- a/openspec/changes/cli-cr-inventory-backend/specs/inventory-ownership/spec.md
+++ b/openspec/changes/cli-cr-inventory-backend/specs/inventory-ownership/spec.md
@@ -1,0 +1,71 @@
+# Delta: inventory-ownership (cli-cr-inventory-backend)
+
+Ownership derives from the CR's `spec.owner` marker instead of the record's `createdBy` provenance.
+
+## ADDED Requirements
+
+### Requirement: spec.owner defines instance ownership
+
+Instance ownership SHALL be determined from the `ModuleInstance` CR's `spec.owner` field. A CR the CLI writes SHALL always carry `spec.owner: cli` explicitly. For reads: an absent CR or `spec.owner: cli` SHALL resolve to CLI-executor mode; `spec.owner: operator` SHALL resolve to operator-owned. (An absent or empty `spec.owner` on an existing CR means operator-managed by the operator's own defaulting contract; the CLI SHALL treat any value other than `cli` as operator-owned.)
+
+#### Scenario: CLI-owned instance
+
+- **WHEN** the CLI reads a `ModuleInstance` with `spec.owner: cli`
+- **THEN** the instance SHALL resolve to CLI-executor mode
+
+#### Scenario: Operator-owned instance
+
+- **WHEN** the CLI reads a `ModuleInstance` with `spec.owner: operator` or without `spec.owner`
+- **THEN** the instance SHALL resolve to operator-owned
+
+### Requirement: Operator-owned instances are refused with actionable errors
+
+In this slice, `opm instance apply` against an operator-owned instance SHALL refuse with an error stating the instance is operator-managed. `opm instance delete` against an operator-owned instance SHALL refuse and hint that `kubectl delete moduleinstance <name>` triggers the operator's finalizer cleanup. Refusals SHALL occur before any resource is applied, pruned, or deleted.
+
+#### Scenario: Apply refused on operator-owned instance
+
+- **WHEN** `opm instance apply` targets a `ModuleInstance` with `spec.owner: operator`
+- **THEN** the command SHALL exit non-zero with an operator-managed error
+- **AND** no resource SHALL have been applied
+
+#### Scenario: Delete refused with kubectl hint
+
+- **WHEN** `opm instance delete` targets an operator-owned instance
+- **THEN** the command SHALL exit non-zero and the error SHALL mention `kubectl delete moduleinstance`
+
+### Requirement: Ownership mode resolution is a single branch point
+
+The mapping from `spec.owner` to a CLI execution mode SHALL be implemented in exactly one function that all mutating commands (`apply`, `delete`) consume, so a later slice can extend operator-owned handling (thin spec-editor mode, enhancement 0006 D18) without changing callers.
+
+#### Scenario: Apply and delete share the resolver
+
+- **WHEN** `apply` and `delete` evaluate ownership for the same CR
+- **THEN** both SHALL obtain their mode from the same resolution function
+
+## MODIFIED Requirements
+
+### Requirement: Ownership is exclusive across tools
+
+The CLI and the operator SHALL treat ownership as exclusive, coordinated through the `ModuleInstance` CR's `spec.owner` field. The CLI MUST NOT act as the resource reconciler (apply, prune, inventory write, status write) for an instance whose `spec.owner` is not `cli`. The operator skips render/apply/prune for `spec.owner: cli` instances (operator-side contract, enhancement 0006 D3/A4).
+
+#### Scenario: CLI sees operator-owned instance
+
+- **WHEN** the CLI loads a `ModuleInstance` whose `spec.owner` is `operator`
+- **THEN** the CLI SHALL treat the instance as not mutable by the CLI's direct-resource path
+
+#### Scenario: Operator sees CLI-owned instance
+
+- **WHEN** the operator reconciles a `ModuleInstance` with `spec.owner: cli`
+- **THEN** the operator SHALL skip render/apply/prune and never touch CLI-written status fields
+
+## REMOVED Requirements
+
+### Requirement: Inventory provenance defines release ownership
+
+**Reason**: The `createdBy` record field is replaced by the CR's `spec.owner` marker (enhancement 0006 D3); ownership is user-intent spec state, not status provenance.
+**Migration**: Migrated CRs are written with `spec.owner: cli`. The `pkg/ownership` `createdBy` constants and record-based enforcement are deleted with the Secret record.
+
+### Requirement: Legacy inventories are treated as CLI-owned
+
+**Reason**: Legacy (pre-provenance) Secret inventories are no longer read outside the one-time migration path, which ports them as CLI-owned.
+**Migration**: The migration writes `spec.owner: cli` for every ported Secret, preserving the legacy assumption.

--- a/openspec/changes/cli-cr-inventory-backend/specs/resource-discovery/spec.md
+++ b/openspec/changes/cli-cr-inventory-backend/specs/resource-discovery/spec.md
@@ -1,0 +1,29 @@
+# Delta: resource-discovery (cli-cr-inventory-backend)
+
+Selector resolution reads the `ModuleInstance` CR instead of Secret-era label selectors. Namespace precedence, `--instance-id` support on `status`, and child traversal are unchanged.
+
+## MODIFIED Requirements
+
+### Requirement: Selector mutual exclusivity
+
+Commands that discover resources (`delete`, `status`) MUST accept exactly one selector type per invocation. Name selectors resolve by a direct `ModuleInstance` GET; instance-id selectors resolve by listing `ModuleInstance` CRs in the namespace and matching `status.instanceUUID`.
+
+#### Scenario: Both --name and --instance-id provided
+
+- **WHEN** user provides both `--name` and `--instance-id` flags
+- **THEN** command exits with error: `"--name and --instance-id are mutually exclusive"`
+
+#### Scenario: Neither --name nor --instance-id provided
+
+- **WHEN** user provides neither `--name` nor `--instance-id` flag
+- **THEN** command exits with error: `"either --name or --instance-id is required"`
+
+#### Scenario: Only --name provided
+
+- **WHEN** user provides `--name` flag (and `--namespace`)
+- **THEN** command resolves the instance by a direct `ModuleInstance` GET by name in the namespace
+
+#### Scenario: Only --instance-id provided
+
+- **WHEN** user provides `--instance-id` flag (and `--namespace`)
+- **THEN** command resolves the instance by listing `ModuleInstance` CRs in the namespace and matching `status.instanceUUID`

--- a/openspec/changes/cli-cr-inventory-backend/specs/secret-inventory-migration/spec.md
+++ b/openspec/changes/cli-cr-inventory-backend/specs/secret-inventory-migration/spec.md
@@ -1,0 +1,58 @@
+# secret-inventory-migration
+
+## Purpose
+
+The one-time, delete-after-success migration of legacy Secret inventories onto the `ModuleInstance` CR, performed on apply. Enhancement 0006 D8 as amended by D14 — no deprecation window; apply is the only command that reads Secrets, and only to migrate them.
+
+## ADDED Requirements
+
+### Requirement: Migration triggers on apply when a Secret exists and no CR does
+
+On `opm instance apply` (and `opm module apply`), when no `ModuleInstance` CR exists for the instance but a legacy inventory Secret does (found by the legacy direct-name and UUID-label lookup), the CLI SHALL migrate: treat the Secret's record as the previous inventory for stale-set computation, proceed with the normal apply, write the CR (spec + status subset, `spec.owner: cli`), and then delete the Secret.
+
+#### Scenario: Secret-tracked instance is migrated on apply
+
+- **WHEN** an instance has a legacy inventory Secret and no `ModuleInstance` CR
+- **AND** `opm instance apply` succeeds
+- **THEN** a `ModuleInstance` CR SHALL exist with the ported inventory
+- **AND** the legacy Secret SHALL be deleted
+
+#### Scenario: Stale-set continuity across migration
+
+- **WHEN** the Secret's record tracks entries [A, B, C] and the current render produces [A, B]
+- **THEN** entry C SHALL be pruned during the migrating apply
+
+### Requirement: Record port mapping
+
+The migration SHALL map the Secret record onto the CR as follows: `inventory` (entries, revision, digest, count) into `status.inventory` with the revision continued (next write increments it, not resets it); the record's instance UUID into `status.instanceUUID`; `spec.owner: cli`; `spec.module` and `spec.values` from the current apply's resolved module and unified values.
+
+#### Scenario: Revision continues
+
+- **WHEN** the Secret record's inventory revision is 4 and the migrating apply succeeds
+- **THEN** the CR's `status.inventory.revision` SHALL be 5
+
+### Requirement: Secret is deleted only after the CR status write succeeds
+
+The migration SHALL delete the legacy Secret only after the CR's status subresource write has succeeded. Any failure before that point SHALL leave the Secret intact. A re-run of apply after a partial migration SHALL be idempotent (CR exists ⇒ normal apply; leftover Secret with an existing CR ⇒ Secret is deleted without being read).
+
+#### Scenario: Failure preserves the Secret
+
+- **WHEN** the migrating apply fails before the CR status write succeeds
+- **THEN** the legacy Secret SHALL still exist
+- **AND** a subsequent apply SHALL retry the migration
+
+#### Scenario: Idempotent re-run after partial migration
+
+- **WHEN** a CR exists and a leftover legacy Secret also exists
+- **AND** apply runs
+- **THEN** the apply SHALL use the CR as the previous inventory and delete the leftover Secret
+
+### Requirement: No Secret reads outside migration
+
+`opm instance status`, `delete`, `list`, and `diff` MUST NOT read legacy inventory Secrets. An instance tracked only by a Secret is invisible to these commands until its next apply migrates it.
+
+#### Scenario: Status does not fall back to Secrets
+
+- **WHEN** an instance has only a legacy Secret inventory (no CR)
+- **AND** `opm instance status --name <name>` runs
+- **THEN** the command SHALL report the instance as not found

--- a/openspec/changes/cli-cr-inventory-backend/tasks.md
+++ b/openspec/changes/cli-cr-inventory-backend/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: cli-cr-inventory-backend
+
+## 1. Foundations (CUE bump + CR store)
+
+- [ ] 1.1 Bump `cuelang.org/go` to v0.17.1 in `go.mod`; `task check` green (design D9; trial-verified — expect zero code changes)
+- [ ] 1.2 Add an integration fixture proving the loader honors `cue.mod/local-module.cue` `replaceWith` (local dir replacing a registry path, including a never-published path); fix loader resolution if it bypasses the SDK's module resolution
+- [ ] 1.3 Define the `ModuleInstance` GVR/kind constants in `internal/inventory`; replace `internal/operator/uninstall.go`'s private `moduleInstanceGVR` with the shared import (design D1)
+- [ ] 1.4 Implement entry↔CRD-wire-shape mapping (`group/kind/namespace/name/v/component`; `inventory.revision/digest/count/entries`) with round-trip unit tests (design D2)
+- [ ] 1.5 Implement the CR store in `internal/inventory`: GET (NotFound ⇒ no inventory), SSA spec apply, SSA status-subresource apply, delete (NotFound ⇒ success), list + `status.instanceUUID` matching — all `unstructured` via the dynamic client, manager `opm-cli` (design D3)
+
+## 2. Ownership and provenance
+
+- [ ] 2.1 Implement the single ownership mode-resolution function (`spec.owner` → mode) replacing `EnsureCLIMutable`/`createdBy`; unit-test all owner values (design D4)
+- [ ] 2.2 Loader records render provenance (main-module-local, or any local-path `replaceWith` in the main module's `local-module.cue`); apply stamps/omits `module-instance.opmodel.dev/source: local` accordingly; test SSA removal on registry re-apply (design D7)
+- [ ] 2.3 Extract `status.instanceUUID` from rendered `module-instance.opmodel.dev/uuid` labels (first non-empty, omit when absent) with unit tests (design D3)
+
+## 3. Pre-apply gate battery
+
+- [ ] 3.1 CRD presence gate with the `opm operator install --crds-only` hint (design D5.1)
+- [ ] 3.2 CRD field-presence floor (`spec.owner` + `status.inventory` in the served storage-version schema), unit-tested against the embedded B2 CRD manifest (design D5.2)
+- [ ] 3.3 Operator-version ceiling reading `Platform.status.operatorVersion`: absent ⇒ skip; RBAC-denied read ⇒ skip with warning; dev build ⇒ skip with warning; semver-older CLI ⇒ refuse (design D5.3)
+- [ ] 3.4 `SelfSubjectAccessReview` pre-flight for `patch moduleinstances/status` (CLI-executor mode only), aborting before any apply with the `--rbac` remedial hint (design D5.5)
+- [ ] 3.5 Wire the gate battery into `internal/workflow/apply` in order (gates → ownership → SSAR → existence check), dry-run exempt; integration-test gate ordering guarantees zero writes on failure
+
+## 4. Apply/delete/status/list/diff rewire
+
+- [ ] 4.1 Rewire `internal/workflow/apply`: previous inventory from the CR, spec write (owner/module/values — canonical declared reference for local applies), stale set + prune via existing logic, status subset write after prune (no conditions), dry-run untouched
+- [ ] 4.2 One-time Secret→CR migration in the apply path: legacy lookup, revision continuation, delete-Secret-after-status-write, idempotent re-run (design D6)
+- [ ] 4.3 Rewire `internal/workflow/query` (status/diff/list health): inventory resolution and per-entry discovery read the CR record; re-home `discover.go` input types
+- [ ] 4.4 Rewire `instance delete`: ownership refusal with kubectl hint, prune from CR entries, delete CR last (replace `InventorySecretName` ordering in `internal/kubernetes/delete.go`)
+- [ ] 4.5 `instance list`: namespace-scoped CR list + `--all-namespaces`/`-A` cluster-wide list with actionable RBAC error; sorted by name; corrupt CRs warned and skipped
+- [ ] 4.6 `instance diff`: orphan detection reads `status.inventory` from the CR
+
+## 5. Deletions and cleanup
+
+- [ ] 5.1 Delete `internal/inventory/{secret.go,crud.go,list.go}` and the Secret-era paths in consumers; keep `pkg/inventory` + `stale.go` untouched; retain Secret unmarshal only inside the migration path
+- [ ] 5.2 Remove `pkg/ownership` `createdBy`-based enforcement (superseded by 2.1); sweep remaining `createdBy`/Secret-name references
+- [ ] 5.3 `task check` (fmt, vet, lint, tests) green across the repo
+
+## 6. Verification and docs
+
+- [ ] 6.1 e2e: first apply creates CR with correct spec/status subset; re-apply increments revision; rename prunes; delete removes CR last (kind cluster, CRDs via `opm operator install --crds-only`)
+- [ ] 6.2 e2e: migration — seed a legacy Secret inventory, apply, assert CR ported + Secret deleted + stale entry pruned; assert status/list do not see unmigrated Secrets
+- [ ] 6.3 e2e: gates — missing CRD hint; SSAR denial aborts pre-apply (namespace-scoped user); ceiling inert against current operator release (field absent ⇒ skip)
+- [ ] 6.4 Update command reference docs + QUICKSTART: CRD prerequisite, `--all-namespaces`, migration note, breaking Secret removal
+- [ ] 6.5 Record the landing `history` event in `enhancements/0006/config.yaml` (slice `cli/<archive-date>-cli-cr-inventory-backend`)
+
+## 7. Blocked on A6 release (do last; independent of 1–6)
+
+- [ ] 7.1 After the opm-operator release carrying `Platform.status.operatorVersion` ships: `task operator:sync VERSION=<tag>` pin bump, then e2e the ceiling gate against a real operator (skip-when-absent + refuse-when-newer paths)

--- a/openspec/specs/cmd-structure/spec.md
+++ b/openspec/specs/cmd-structure/spec.md
@@ -43,6 +43,12 @@ The `internal/cmd/` package SHALL be split into sub-packages that mirror the cob
 - **AND** the `instance build` subcommand SHALL accept either an instance `.cue` file or a module-package directory as its positional argument
 - **AND** when the argument is a directory the subcommand SHALL delegate to the same module-synthesis path used by `opm module build`
 
+#### Scenario: operator commands are in their own package
+
+- **WHEN** the `internal/cmd/operator/` directory is inspected
+- **THEN** it SHALL contain the `operator` sub-command implementations: `install`, `uninstall`
+- **AND** the commands SHALL be thin cobra wiring that delegates all behavior to `internal/operator/`
+
 ### Requirement: Instance command group registered at root level
 
 The root command SHALL register `opm instance` (alias: `inst`) as a top-level command group via `cmdinstance.NewInstanceCmd(&cfg)`. This SHALL follow the same dependency injection pattern as `mod` and `config` groups. The former `cmdrelease.NewReleaseCmd` registration is removed (no back-compat alias — enhancement 0002 D8).
@@ -52,6 +58,16 @@ The root command SHALL register `opm instance` (alias: `inst`) as a top-level co
 - **WHEN** `internal/cmd/root.go` is inspected
 - **THEN** it SHALL contain `rootCmd.AddCommand(cmdinstance.NewInstanceCmd(&cfg))`
 - **AND** it SHALL NOT contain `cmdrelease.NewReleaseCmd`
+
+### Requirement: Operator command group registered at root level
+
+The root command SHALL register `opm operator` as a top-level command group via `cmdoperator.NewOperatorCmd(&cfg)`, following the same `GlobalConfig` dependency-injection pattern as the `module`, `instance`, and `config` groups. The group is noun-first (enhancement 0006 D32): there are no `opm install` or `opm uninstall` verb groups at root level.
+
+#### Scenario: Root command registers operator group
+
+- **WHEN** `internal/cmd/root.go` is inspected
+- **THEN** it SHALL contain `rootCmd.AddCommand(cmdoperator.NewOperatorCmd(&cfg))`
+- **AND** the root command SHALL NOT register `install` or `uninstall` as top-level commands
 
 ### Requirement: Cluster-query commands migrate from mod to instance
 

--- a/openspec/specs/k8s-helpers/spec.md
+++ b/openspec/specs/k8s-helpers/spec.md
@@ -43,7 +43,7 @@ The `*Client` type SHALL provide a `ResourceClient` method that accepts a `schem
 
 #### Scenario: Apply uses ResourceClient for GET and PATCH
 
-- **WHEN** `applyResource` performs a GET to check existing state and a PATCH to apply
+- **WHEN** `ApplyOne` performs a GET to check existing state and a PATCH to apply
 - **THEN** both operations SHALL use `client.ResourceClient(gvr, ns)` instead of inline `if ns != ""` branching
 
 #### Scenario: Delete uses ResourceClient

--- a/openspec/specs/operator-lifecycle/spec.md
+++ b/openspec/specs/operator-lifecycle/spec.md
@@ -1,0 +1,139 @@
+## Purpose
+
+Operator lifecycle surface: `opm operator install` / `opm operator uninstall`, the embedded pinned operator manifest, readiness waits, uninstall safety, and the CLI's server-side-apply field-manager identity. Slice B2 of enhancement 0006 (D5, D23, D32–D35).
+
+## Requirements
+
+### Requirement: Full operator install from the embedded manifest
+
+`opm operator install` SHALL server-side-apply every document of the embedded operator manifest (`dist/install.yaml` of the pinned opm-operator release) with field manager `opm-cli`, ordered ascending by the resource weights of `pkg/resourceorder` (CRDs before Namespace before RBAC before Deployment). The command SHALL then wait, bounded by `--timeout` (default 5m), for every applied CRD to reach the `Established=True` condition and for the operator Deployment to complete its rollout, and SHALL exit non-zero with an actionable error if the timeout elapses first.
+
+#### Scenario: Install onto an empty cluster
+
+- **WHEN** `opm operator install` is run against a cluster with no OPM components
+- **THEN** all manifest documents are applied via SSA with field manager `opm-cli`
+- **AND** the command reports a per-resource status line (created/configured/unchanged) for each document
+- **AND** the command waits until the CRDs are `Established` and the operator Deployment rollout completes, then exits zero
+
+#### Scenario: Install is idempotent
+
+- **WHEN** `opm operator install` is run a second time with no cluster-side changes in between
+- **THEN** every document reports `unchanged` and the command exits zero
+
+#### Scenario: Readiness timeout
+
+- **WHEN** the operator Deployment cannot become ready within `--timeout`
+- **THEN** the command exits non-zero with an error naming the resource still unready and the elapsed timeout
+
+### Requirement: CRDs-only install via `--crds-only`
+
+`opm operator install --crds-only` SHALL apply only the `CustomResourceDefinition` documents filtered from the same embedded manifest, and SHALL wait only for the `Established=True` condition on those CRDs. No Namespace, RBAC, Deployment, or Service objects are created.
+
+#### Scenario: Solo-cluster CRD install
+
+- **WHEN** `opm operator install --crds-only` is run against an empty cluster
+- **THEN** exactly the manifest's `CustomResourceDefinition` documents are applied
+- **AND** the command waits for each to report `Established=True` and exits zero
+- **AND** no other kinds from the manifest exist on the cluster afterwards
+
+### Requirement: Single embedded artifact with a pinned version
+
+The CLI SHALL embed exactly one operator artifact — the pinned opm-operator release's `dist/install.yaml` — and SHALL derive every install/uninstall plan (full set, CRD subset, uninstall set) by filtering that one parsed artifact. The pinned release tag SHALL be recorded in a single Go constant adjacent to the embed directive, and a `task operator:sync VERSION=<tag>` task SHALL refresh both the embedded file and the constant from the corresponding opm-operator GitHub release asset.
+
+#### Scenario: CRD subset cannot drift from the full install
+
+- **WHEN** the source tree is inspected
+- **THEN** `dist/install.yaml` is the only embedded operator manifest (no separately embedded CRD files)
+- **AND** the CRDs-only plan is produced by filtering the parsed manifest for `kind: CustomResourceDefinition`
+
+#### Scenario: Pin refresh is a single reviewable diff
+
+- **WHEN** `task operator:sync VERSION=v1.0.0-alpha.3` is run
+- **THEN** the embedded `install.yaml` is replaced with that release's asset and the pin constant is rewritten to `v1.0.0-alpha.3`, with no other source changes
+
+### Requirement: `--version` fetches the release asset instead of the embed
+
+`opm operator install --version <tag>` SHALL fetch `install.yaml` from the opm-operator GitHub release `<tag>` over HTTPS and feed it through the same parse/plan/apply path as the embedded artifact. Fetch failures SHALL produce a clear error naming the tag and URL; no checksum or signature verification is performed at this stage (0006/D35). The command output SHALL name which version was installed and whether it came from the embed or a fetch.
+
+#### Scenario: Fetching a valid tag
+
+- **WHEN** `opm operator install --version v1.0.0-alpha.1` is run with network access
+- **THEN** the manifest is downloaded from that release's `install.yaml` asset and applied
+- **AND** the output states the installed version and its fetched origin
+
+#### Scenario: Fetching a missing tag
+
+- **WHEN** `opm operator install --version v9.9.9` is run and the release or asset does not exist
+- **THEN** the command exits non-zero with an error naming the tag and the attempted URL, and applies nothing
+
+### Requirement: Opt-in RBAC emission via `--rbac`
+
+`opm operator install --rbac` SHALL additionally create a ClusterRole `opm-cli-user` granting full verbs on `moduleinstances`, `get/patch/update` on `moduleinstances/status`, and `get/list` on `platforms`. When `--user <U>` or `--group <G>` is supplied alongside `--rbac`, the command SHALL also create a ClusterRoleBinding binding that subject to the role. Without `--rbac`, no RBAC objects beyond the manifest's own are created. `--user`/`--group` without `--rbac` SHALL be rejected as a flag-validation error before any cluster interaction.
+
+#### Scenario: RBAC off by default
+
+- **WHEN** `opm operator install --crds-only` is run
+- **THEN** no `opm-cli-user` ClusterRole or ClusterRoleBinding is created
+
+#### Scenario: Role plus binding for a user
+
+- **WHEN** `opm operator install --crds-only --rbac --user alice` is run
+- **THEN** the `opm-cli-user` ClusterRole and a ClusterRoleBinding for user `alice` are applied with field manager `opm-cli`
+
+#### Scenario: Subject flags require --rbac
+
+- **WHEN** `opm operator install --user alice` is run without `--rbac`
+- **THEN** the command fails flag validation with an error stating `--user`/`--group` require `--rbac`, before contacting the cluster
+
+### Requirement: Uninstall preserves CRDs and the Namespace
+
+`opm operator uninstall` SHALL delete the embedded manifest's documents except every `CustomResourceDefinition` and the `Namespace`, in descending resource-weight order. CRD removal remains a deliberate manual `kubectl delete crd`. The command SHALL NOT wait for deletion to complete (fire-and-report). A deleted resource that is already absent (NotFound) counts as success, so re-running `uninstall` after a prior successful or partial run is idempotent.
+
+#### Scenario: Uninstall after a full install
+
+- **WHEN** `opm operator uninstall` is run on a cluster with no `ModuleInstance` resources
+- **THEN** the operator Deployment, Service, RBAC objects, and ServiceAccount are deleted
+- **AND** the three OPM CRDs and the operator Namespace still exist afterwards
+
+#### Scenario: Re-running uninstall after a successful uninstall
+
+- **WHEN** `opm operator uninstall` is run again after a prior run already deleted everything it targets
+- **THEN** the command exits zero, treating each already-absent resource as successfully deleted
+
+### Requirement: Uninstall refuses while operator cleanup finalizers are armed
+
+Before deleting anything, `opm operator uninstall` SHALL list `ModuleInstance` resources cluster-wide; if any carries the `opmodel.dev/cleanup` finalizer, the command SHALL refuse (exit non-zero) and name each such instance as `namespace/name`. With `--remove-finalizers`, the command SHALL attempt to remove exactly the `opmodel.dev/cleanup` finalizer (leaving all other finalizers intact) from every such instance, state that the instances and their workloads are now orphaned, and then proceed to delete only if every armed instance was successfully stripped. If the cluster-wide list fails (including RBAC denial), the command SHALL fail closed without deleting anything.
+
+#### Scenario: Refusal names the armed instances
+
+- **WHEN** `opm operator uninstall` is run while `default/jellyfin` carries the `opmodel.dev/cleanup` finalizer
+- **THEN** the command exits non-zero without deleting anything
+- **AND** the error names `default/jellyfin` and points at `--remove-finalizers` and its orphaning consequence
+
+#### Scenario: Override strips only the operator's finalizer
+
+- **WHEN** `opm operator uninstall --remove-finalizers` is run while an instance carries both `opmodel.dev/cleanup` and a foreign finalizer
+- **THEN** `opmodel.dev/cleanup` is removed from the instance, the foreign finalizer remains
+- **AND** the command states the orphaning consequence and proceeds with the uninstall
+
+#### Scenario: List failure fails closed
+
+- **WHEN** the uninstalling user lacks permission to list `moduleinstances` cluster-wide
+- **THEN** the command exits non-zero without deleting anything, mapping the RBAC error to the standard permission-denied exit code
+
+#### Scenario: Partial finalizer-removal failure blocks the delete step
+
+- **WHEN** `--remove-finalizers` is given and stripping the finalizer fails for one of several armed instances
+- **THEN** the command still attempts every armed instance rather than stopping at the first failure
+- **AND** the returned error names every instance that failed
+- **AND** the operator's own resources are not deleted unless every armed instance was successfully stripped
+
+### Requirement: All CLI server-side-apply writes use field manager `opm-cli`
+
+Every server-side-apply write the CLI performs — instance/module applies and operator installs alike — SHALL use the field manager `opm-cli`. The former manager name `opm` is retired; ownership of resources previously applied under `opm` transfers on their next apply via the existing forced-conflicts behavior, with no user-visible change.
+
+#### Scenario: One manager identity across the CLI
+
+- **WHEN** any resource is applied by any CLI command after this change
+- **THEN** its `managedFields` attribute the CLI's fields to manager `opm-cli`
+- **AND** no CLI code path applies with manager `opm`

--- a/tests/e2e/operator_test.go
+++ b/tests/e2e/operator_test.go
@@ -1,0 +1,315 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kindContext is the kind cluster context these tests run against. Matches
+// TestMain's dummy config.cue and the workspace's `task cluster:create`.
+const kindContext = "kind-opm-dev"
+
+// pinnedInstallYAML locates the embedded operator manifest so the pinned
+// image reference can be read directly, instead of duplicating it here where
+// it would silently go stale after a `task operator:sync`.
+const pinnedInstallYAMLRelPath = "../../internal/operator/dist/install.yaml"
+
+var pinnedImageRe = regexp.MustCompile(`image:\s*(\S+)`)
+
+// requireKindCluster skips the test if the kind-opm-dev cluster is not
+// reachable, and returns the real (non-HOME-overridden) kubeconfig path.
+func requireKindCluster(t *testing.T) string {
+	t.Helper()
+
+	realHome, err := os.UserHomeDir()
+	require.NoError(t, err)
+	kubeconfig := filepath.Join(realHome, ".kube", "config")
+	if _, statErr := os.Stat(kubeconfig); statErr != nil {
+		t.Skipf("no kubeconfig at %q; skipping operator e2e", kubeconfig)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig, "--context", kindContext,
+		"cluster-info").Run(); err != nil {
+		t.Skipf("kind cluster %q not reachable; run `task cluster:create`: %v", kindContext, err)
+	}
+
+	return kubeconfig
+}
+
+// pinnedOperatorImage reads the pinned image reference out of the embedded
+// manifest, so the pull-reachability check always matches what `install`
+// actually applies.
+func pinnedOperatorImage(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile(pinnedInstallYAMLRelPath)
+	require.NoError(t, err)
+
+	m := pinnedImageRe.FindSubmatch(data)
+	require.NotNil(t, m, "could not find image: reference in %s", pinnedInstallYAMLRelPath)
+	return string(m[1])
+}
+
+// imagePullable reports whether the pinned operator image's manifest is
+// reachable, without pulling any layers. Used to decide (design risk 1)
+// whether the full-install test can assert a completed rollout, or must
+// fall back to asserting CRD Established + Deployment created.
+func imagePullable(t *testing.T, image string) bool {
+	t.Helper()
+
+	if _, err := exec.LookPath("crane"); err != nil {
+		t.Logf("crane not available; treating %s as unpullable for this run", image)
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(ctx, "crane", "manifest", image).Run(); err != nil {
+		t.Logf("crane manifest %s failed, treating as unpullable: %v", image, err)
+		return false
+	}
+	return true
+}
+
+// kubectlOut runs kubectl against the kind-opm-dev cluster and returns
+// trimmed stdout.
+func kubectlOut(t *testing.T, kubeconfig string, args ...string) string {
+	t.Helper()
+
+	fullArgs := append([]string{"--kubeconfig", kubeconfig, "--context", kindContext}, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "kubectl", fullArgs...).Output()
+	require.NoError(t, err, "kubectl %s", strings.Join(args, " "))
+	return strings.TrimSpace(string(out))
+}
+
+// kubectlDeleteIfExists best-effort deletes a resource, ignoring absence.
+// Waits for the delete to actually complete (default kubectl behavior) so
+// callers can rely on the resource being gone once this returns — cheap
+// here since it only ever runs against test fixtures with no real workloads.
+func kubectlDeleteIfExists(t *testing.T, kubeconfig string, args ...string) {
+	t.Helper()
+
+	fullArgs := append([]string{"--kubeconfig", kubeconfig, "--context", kindContext, "delete", "--ignore-not-found", "--timeout=60s"}, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	_ = exec.CommandContext(ctx, "kubectl", fullArgs...).Run()
+}
+
+func assertCRDEstablished(t *testing.T, kubeconfig, name string) {
+	t.Helper()
+	status := kubectlOut(t, kubeconfig, "get", "crd", name,
+		"-o", `jsonpath={.status.conditions[?(@.type=="Established")].status}`)
+	assert.Equal(t, "True", status, "CRD %s should be Established", name)
+}
+
+func assertResourceExists(t *testing.T, kubeconfig, kind, namespace, name string) {
+	t.Helper()
+	args := []string{"get", kind, name, "-o", "name"}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	out := kubectlOut(t, kubeconfig, args...)
+	assert.NotEmpty(t, out, "%s/%s should exist", kind, name)
+}
+
+// stripAllModuleInstanceFinalizers force-clears finalizers on every
+// ModuleInstance so a subsequent delete can't wedge waiting on one that
+// nothing will ever remove (there's no real operator running in this suite
+// to do it). Best-effort: silently no-ops if the CRD isn't installed.
+func stripAllModuleInstanceFinalizers(t *testing.T, kubeconfig string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig, "--context", kindContext,
+		"get", "moduleinstances.opmodel.dev", "--all-namespaces",
+		"-o", `jsonpath={range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{"\n"}{end}`).Output()
+	if err != nil {
+		return // CRD not installed — nothing to strip.
+	}
+
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		ns, name, ok := strings.Cut(line, "/")
+		if !ok {
+			continue
+		}
+		pctx, pcancel := context.WithTimeout(context.Background(), 15*time.Second)
+		_ = exec.CommandContext(pctx, "kubectl", "--kubeconfig", kubeconfig, "--context", kindContext,
+			"patch", "moduleinstance", name, "-n", ns, "--type=merge", "-p", `{"metadata":{"finalizers":[]}}`).Run()
+		pcancel()
+	}
+}
+
+// resetOperatorCluster removes everything the operator manifest can create,
+// including CRDs and the Namespace (which `opm operator uninstall` itself
+// deliberately never touches), so each e2e run starts from a clean slate.
+func resetOperatorCluster(t *testing.T, kubeconfig string) {
+	t.Helper()
+	stripAllModuleInstanceFinalizers(t, kubeconfig)
+	kubectlDeleteIfExists(t, kubeconfig, "moduleinstances.opmodel.dev", "--all-namespaces", "--all")
+	kubectlDeleteIfExists(t, kubeconfig, "crd", "moduleinstances.opmodel.dev", "modulepackages.opmodel.dev", "platforms.opmodel.dev")
+	kubectlDeleteIfExists(t, kubeconfig, "namespace", "opm-operator-system")
+	kubectlDeleteIfExists(t, kubeconfig, "clusterrole", "opm-cli-user",
+		"opm-operator-manager-role", "opm-operator-metrics-auth-role", "opm-operator-metrics-reader",
+		"opm-operator-moduleinstance-admin-role", "opm-operator-moduleinstance-editor-role", "opm-operator-moduleinstance-viewer-role")
+	kubectlDeleteIfExists(t, kubeconfig, "clusterrolebinding", "opm-cli-user",
+		"opm-operator-manager-rolebinding", "opm-operator-metrics-auth-rolebinding")
+}
+
+// TestE2E_Operator_InstallUninstallLifecycle exercises the full
+// `opm operator install`/`uninstall` lifecycle against a real kind cluster:
+// full install (waiting for readiness if the pinned image is reachable, else
+// just CRD-established + Deployment-created — design risk 1), idempotent
+// re-install, uninstall's finalizer guard and its --remove-finalizers
+// override (CRDs/Namespace surviving throughout), and a solo --crds-only
+// install onto a freshly reset cluster.
+func TestE2E_Operator_InstallUninstallLifecycle(t *testing.T) {
+	kubeconfig := requireKindCluster(t)
+	image := pinnedOperatorImage(t)
+
+	t.Cleanup(func() { resetOperatorCluster(t, kubeconfig) })
+	resetOperatorCluster(t, kubeconfig)
+
+	tmpDir, err := os.MkdirTemp("", "e2e-operator-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	pullable := imagePullable(t, image)
+	t.Logf("pinned image %s pullable: %v", image, pullable)
+
+	t.Run("install", func(t *testing.T) {
+		waitTimeout := 15 * time.Second
+		if pullable {
+			waitTimeout = 150 * time.Second
+		}
+
+		stdout, stderr, err := runOPMWithEnv(t, tmpDir, homeDir, waitTimeout+30*time.Second,
+			"operator", "install",
+			"--kubeconfig", kubeconfig, "--context", kindContext,
+			"--timeout", waitTimeout.String())
+
+		if pullable {
+			require.NoError(t, err, "stdout=%s stderr=%s", stdout, stderr)
+			assertResourceHealthy(t, kubeconfig, "deployment", "opm-operator-system", "opm-operator-controller-manager")
+		} else {
+			// The apply phase (before the readiness wait) still ran —
+			// only the Deployment rollout wait times out.
+			require.Error(t, err, "stdout=%s stderr=%s", stdout, stderr)
+		}
+
+		assertCRDEstablished(t, kubeconfig, "moduleinstances.opmodel.dev")
+		assertCRDEstablished(t, kubeconfig, "modulepackages.opmodel.dev")
+		assertCRDEstablished(t, kubeconfig, "platforms.opmodel.dev")
+		assertResourceExists(t, kubeconfig, "namespace", "", "opm-operator-system")
+		assertResourceExists(t, kubeconfig, "deployment", "opm-operator-system", "opm-operator-controller-manager")
+	})
+
+	t.Run("idempotent re-install reports unchanged", func(t *testing.T) {
+		_, stderr, err := runOPMWithEnv(t, tmpDir, homeDir, 30*time.Second,
+			"operator", "install", "--crds-only",
+			"--kubeconfig", kubeconfig, "--context", kindContext, "--timeout", "15s")
+		require.NoError(t, err, "stderr=%s", stderr)
+		assert.Equal(t, 3, strings.Count(stderr, "unchanged"), "stderr=%s", stderr)
+	})
+
+	t.Run("uninstall refuses while a finalizer is armed, then --remove-finalizers proceeds", func(t *testing.T) {
+		applyArmedModuleInstance(t, kubeconfig, "default", "e2e-jellyfin")
+		t.Cleanup(func() {
+			// Strip finalizers first: with the remaining foreign finalizer,
+			// a plain delete would hang forever waiting on a controller
+			// that isn't running in this suite.
+			stripAllModuleInstanceFinalizers(t, kubeconfig)
+			kubectlDeleteIfExists(t, kubeconfig, "moduleinstance", "e2e-jellyfin", "-n", "default")
+		})
+
+		_, stderr, err := runOPMWithEnv(t, tmpDir, homeDir, 30*time.Second,
+			"operator", "uninstall", "--kubeconfig", kubeconfig, "--context", kindContext)
+		require.Error(t, err)
+		assert.Contains(t, stderr, "default/e2e-jellyfin")
+		assert.Contains(t, stderr, "--remove-finalizers")
+		// Refused: the Deployment this scenario relies on for the "survives"
+		// check further down must still be present.
+		assertResourceExists(t, kubeconfig, "deployment", "opm-operator-system", "opm-operator-controller-manager")
+
+		_, stderr, err = runOPMWithEnv(t, tmpDir, homeDir, 30*time.Second,
+			"operator", "uninstall", "--remove-finalizers",
+			"--kubeconfig", kubeconfig, "--context", kindContext)
+		require.NoError(t, err, "stderr=%s", stderr)
+
+		finalizers := kubectlOut(t, kubeconfig, "get", "moduleinstance", "e2e-jellyfin", "-n", "default",
+			"-o", "jsonpath={.metadata.finalizers}")
+		assert.JSONEq(t, `["example.com/foreign"]`, finalizers)
+
+		// CRDs and the Namespace survive uninstall.
+		assertCRDEstablished(t, kubeconfig, "moduleinstances.opmodel.dev")
+		assertResourceExists(t, kubeconfig, "namespace", "", "opm-operator-system")
+	})
+
+	t.Run("crds-only on a fresh cluster installs only the CRDs", func(t *testing.T) {
+		resetOperatorCluster(t, kubeconfig)
+
+		stdout, stderr, err := runOPMWithEnv(t, tmpDir, homeDir, 30*time.Second,
+			"operator", "install", "--crds-only",
+			"--kubeconfig", kubeconfig, "--context", kindContext, "--timeout", "15s")
+		require.NoError(t, err, "stdout=%s stderr=%s", stdout, stderr)
+
+		assertCRDEstablished(t, kubeconfig, "moduleinstances.opmodel.dev")
+		assertCRDEstablished(t, kubeconfig, "modulepackages.opmodel.dev")
+		assertCRDEstablished(t, kubeconfig, "platforms.opmodel.dev")
+
+		out := kubectlOut(t, kubeconfig, "get", "namespace", "opm-operator-system", "--ignore-not-found", "-o", "name")
+		assert.Empty(t, out, "no Namespace should exist after a --crds-only install")
+	})
+}
+
+// assertResourceHealthy asserts a Deployment has completed its rollout.
+func assertResourceHealthy(t *testing.T, kubeconfig, kind, namespace, name string) {
+	t.Helper()
+	ready := kubectlOut(t, kubeconfig, "get", kind, name, "-n", namespace,
+		"-o", `jsonpath={.status.conditions[?(@.type=="Available")].status}`)
+	assert.Equal(t, "True", ready, "%s/%s should be Available", kind, name)
+}
+
+// applyArmedModuleInstance creates a minimal ModuleInstance carrying the
+// operator's cleanup finalizer plus an unrelated one, to exercise the
+// uninstall finalizer guard without needing a running operator.
+func applyArmedModuleInstance(t *testing.T, kubeconfig, namespace, name string) {
+	t.Helper()
+
+	manifest := `apiVersion: opmodel.dev/v1alpha1
+kind: ModuleInstance
+metadata:
+  name: ` + name + `
+  namespace: ` + namespace + `
+  finalizers:
+  - opmodel.dev/cleanup
+  - example.com/foreign
+spec:
+  module:
+    path: opmodel.dev/modules/e2e-fixture@v0
+    version: v0.0.0
+`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig, "--context", kindContext, "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "applying armed ModuleInstance fixture: %s", out)
+}

--- a/tests/fixtures/valid/secrets-module/cue.mod/module.cue
+++ b/tests/fixtures/valid/secrets-module/cue.mod/module.cue
@@ -13,6 +13,6 @@ deps: {
 		v: "v1.3.10"
 	}
 	"opmodel.dev/opm/v1alpha1@v1": {
-		v: "v1.5.9"
+		v: "v1.6.0"
 	}
 }

--- a/tests/integration/module-apply/testdata/cue.mod/module.cue
+++ b/tests/integration/module-apply/testdata/cue.mod/module.cue
@@ -10,6 +10,6 @@ deps: {
 		v: "v1.3.10"
 	}
 	"opmodel.dev/opm/v1alpha1@v1": {
-		v: "v1.5.9"
+		v: "v1.6.0"
 	}
 }


### PR DESCRIPTION
Drafts the OpenSpec change for enhancement 0006 slice C1 (ModuleInstance CR inventory backend): proposal, design, 6 spec deltas, 25 tasks. Branch is the stale B2 branch — effective diff vs main is only the new `openspec/changes/cli-cr-inventory-backend/` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)