### PR TITLE
chore: drop the sticky release-as override from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,6 @@
       "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "alpha",
-      "release-as": "1.0.0-alpha",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Problem

release-please PR #109 proposes releasing **`1.0.0-alpha`** — but that tag already exists (`v1.0.0-alpha`, released 2026-06-30). We can't cut it twice, and it should be advancing to `1.0.0-alpha.1`.

## Cause

`release-please-config.json` carries `"release-as": "1.0.0-alpha"`. Unlike a one-shot `Release-As:` commit footer, `release-as` **in the config file is applied on every run** until removed — so it pins every release PR to `1.0.0-alpha`, blocking the prerelease counter from advancing.

It was added in #96 to bootstrap the graduation from the `v0.x` line onto the `v1` alpha prerelease line. That release has shipped (`v1.0.0-alpha`), so the override has served its purpose.

## Fix

Remove the `release-as` line. The manifest already records `1.0.0-alpha` as current, so with the override gone release-please resumes normal prerelease incrementing → the next release becomes **`1.0.0-alpha.1`**.

This aligns the CLI with the sibling repos (library, core, opm-operator, catalog_opm), **none** of which carry `release-as`; catalog_opm sits at `1.0.0-alpha.1` with the otherwise-identical prerelease config.

## After merge

release-please re-runs on push to `main` and will update its release PR (#109) to target `1.0.0-alpha.1`. No change to the manifest is needed.