### PR TITLE
docs(operator): refresh stale version examples to v1.0.0-alpha.4

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -320,7 +320,7 @@ tasks:
       The whole upgrade is one reviewable diff.
 
       Usage:
-        task operator:sync VERSION=v1.0.0-alpha.3
+        task operator:sync VERSION=v1.0.0-alpha.4
     vars:
       VERSION: '{{.VERSION | default ""}}'
     preconditions:

--- a/internal/cmd/operator/install.go
+++ b/internal/cmd/operator/install.go
@@ -51,7 +51,7 @@ Examples:
   opm operator install --crds-only --rbac --user alice
 
   # Install a specific opm-operator release instead of the embedded pin
-  opm operator install --version v1.0.0-alpha.3`,
+  opm operator install --version v1.0.0-alpha.4`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runOperatorInstall(cfg, &kf, installFlags{


### PR DESCRIPTION
Two stale `v1.0.0-alpha.3` help-text examples (operator:sync task help, `opm operator install --version` example) refreshed to the current pin. Found by 0006 A5's workspace consumer audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)