### PR TITLE
docs(openspec): draft test-coverage-and-fixture-hygiene change

### DIFF
--- a/openspec/changes/test-coverage-and-fixture-hygiene/.openspec.yaml
+++ b/openspec/changes/test-coverage-and-fixture-hygiene/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/test-coverage-and-fixture-hygiene/design.md
+++ b/openspec/changes/test-coverage-and-fixture-hygiene/design.md
@@ -1,0 +1,38 @@
+# Design: test-coverage-and-fixture-hygiene
+
+## Context
+
+The audit's cli findings split into "spec'd but untested" (annotation SSA-clear, migration failure/idempotence, gate ordering/dry-run, fallback banner) and "fixture debt" (two coexisting schema lineages, a sibling-checkout dependency in render-parity, sixfold helper duplication). The fake dynamic client cannot express SSA removal-on-omit — established by the `ssa-ownership` program's header — which is why the annotation and any omit-semantics coverage must be live; conversely the migration *failure* path is unreachable live (no clean way to make a real status write fail) and belongs to the fake client, whose reactor mechanism can inject exactly that failure.
+
+## Goals / Non-Goals
+
+**Goals:** close the four test gaps at their correct tiers; one schema lineage across maintained fixtures; render-parity self-contained in this repo.
+
+**Non-Goals:** blueprint/primitive testing (enhancements#6 framework); the live refuse-when-newer ceiling e2e (rides the e2e suite against the dev operator — already tracked as C1 task 7.1's residual); rewriting the integration-program architecture (helper consolidation is optional, not a goal).
+
+## Decisions
+
+### LD1: Tier assignment follows what each harness can express
+
+- **Live (kind)**: annotation write + SSA-clear-on-omit (ssa-ownership program — one new step pair using its existing live-object assertion helpers); migration idempotence (migration program — stage CR-present + leftover-Secret, run apply, assert single clean state after).
+- **Unit (fake + reactor)**: migration failure — a `PrependReactor` on the status-subresource apply returning an error; assert the legacy Secret survives in the tracker and no delete action was recorded. This asserts the *ordering contract* (status success gates deletion) without pretending the fake models SSA.
+- **Unit (probe recording)**: gate order — a fake client whose reactors append probe identities to a slice; assert exact sequence CRD-presence → field-floor → ceiling. Dry-run — `Execute` with dry-run against a fake with **no** CRD registered: success and zero recorded probes.
+- **Unit (output capture)**: the fallback banner — run the apply-path platform resolution with no flag and a failing cluster getter, capturing the CLI's output sink; assert the D21 warning text (source provenance) is emitted. Uses/extends whatever capture hook `internal/output` already provides for tests; if none exists, add the minimal writer-swap seam (test-only).
+
+### LD2: Fixture lineage — port when the target line exists, retire visibly when not
+
+`tests/fixtures/valid/*` port to `core@v1` data-file form (the shape the handoff/inst-tree fixtures established); their vet tests keep asserting the same behaviors (valid module, secrets discovery, debug values). `examples/instances/jellyfin` ports (jellyfin@v2 is published on the v1 line); examples whose modules never moved lines (verify garage, mc_java_fleet against the registry) move to `examples/legacy/` with a README stating they document the retired v0 line — visible retirement, not deletion, since they remain the only worked examples of those modules. `examples/cue.mod` follows the port. `mc_router` (mod_build_test's registry-backed module) is verified against the current line and ported or the test's fixture swapped to a v1-line module.
+
+### LD3: Vendor the podinfo fixture, note provenance
+
+Copy `test/fixtures/modules/podinfo` from opm-operator into `cli/tests/fixtures/modules/podinfo` with a header comment naming the origin and that drift is acceptable — render-parity's correctness comes from comparing the CLI and kernel paths over the *same* fixture, not from matching the operator's copy byte-for-byte. `render-parity/main.go` drops the `../opm-operator` path.
+
+### LD4: Helper consolidation is opportunistic
+
+The six copy-pasted helper sets (`opmLabels`/`buildCM`/`writeInventoryCR`/wait helpers) consolidate into a shared non-ignored package under `tests/integration/` only if the `//go:build ignore` mains can import it without losing their run-directly property (they can — ignore-tagged mains may import normal packages). Attempt it; if any friction appears, skip without guilt — duplication is annoying, not dangerous.
+
+## Risks / Trade-offs
+
+- [Output-capture seam doesn't exist and adding one touches production code] → keep it to a test-only writer swap in `internal/output`; if it grows beyond trivial, split the banner test out rather than expanding scope.
+- [Old-line example modules unresolvable during port verification] → that *is* the retirement signal; record per-example disposition in the tasks.
+- [Vendored podinfo drifts from operator's copy] → accepted by design (LD3); parity compares paths, not repos.

--- a/openspec/changes/test-coverage-and-fixture-hygiene/proposal.md
+++ b/openspec/changes/test-coverage-and-fixture-hygiene/proposal.md
@@ -1,0 +1,35 @@
+# Proposal: test-coverage-and-fixture-hygiene
+
+Test and fixture change from the 2026-07-21 workspace fixture audit. No product behavior changes.
+
+## Why
+
+Four spec'd behaviors lack the test that proves them, and the fixture tree carries two schema lineages plus a cross-repo dependency:
+
+1. **Provenance annotation SSA-clear is still fake-client-only.** `instance-inventory`'s "Registry apply clears the annotation" scenario is asserted only against the fake dynamic client (`patch_test.go`), which — by the `ssa-ownership` program's own header — cannot model server-side-apply's removal-on-omit. This annotation is a fail-closed handoff gate input (0006 D38); C1's VERIFICATION-NOTES flagged the gap and it remains open.
+2. **Migration failure/idempotence are spec'd, untested.** `secret-inventory-migration`'s "Failure preserves the Secret" and "Idempotent re-run after partial migration" scenarios have no tests; delete-after-status ordering is the migration's entire safety property and only its happy path runs.
+3. **Gate ordering, dry-run exemption, and the platform-fallback warning banner** are spec'd (`apply-preflight-gates`, `platform-resolution`) but only implicit in source — no test pins the order, the dry-run skip, or that apply actually emits the D21 provenance warning.
+4. **Fixture lineage drift**: `examples/instances/*` still import the retired `modulerelease@v1`/`core/v1alpha1` line; `tests/fixtures/valid/*` pin it too; `render-parity` loads its module fixture from the **sibling opm-operator checkout** (`../opm-operator/test/fixtures/modules/podinfo`), breaking standalone clones; six integration programs copy-paste the same helper set.
+
+## What Changes
+
+- **ssa-ownership program** gains the annotation step: `ApplySpec` with `SourceLocal: true` → live annotation present; re-apply `false` → live annotation removed by SSA.
+- **Migration coverage**: unit test with a fake-client reactor forcing the status write to fail → legacy Secret retained (delete never issued); live idempotence scenario in the migration program (CR exists + leftover Secret → normal apply, Secret cleaned, no duplicate migration).
+- **Unit assertions**: `RunClusterGates` probe order (CRD presence → field floor → ceiling); dry-run apply performs zero gate probes and succeeds against a CRD-less cluster; apply emits the local-default fallback warning banner.
+- **Fixture hygiene**: port `tests/fixtures/valid/*` and portable `examples/instances/*` to the `core@v1` line (retire unportable examples to a marked legacy location); vendor the podinfo module fixture into `cli/tests/fixtures/` and point `render-parity` at it; verify `examples/modules/mc_router` (used by `mod_build_test`) against the current line. Optional: consolidate the duplicated integration-program helpers.
+
+## Capabilities
+
+### New Capabilities
+
+- `test-fixture-lineage`: maintained fixtures and examples track the current published schema line, and repo tests depend only on repo-local fixtures.
+
+### Modified Capabilities
+
+None — every test addition implements scenarios already present in `instance-inventory`, `secret-inventory-migration`, `apply-preflight-gates`, and `platform-resolution`.
+
+## Impact
+
+- **Packages**: `tests/integration/{ssa-ownership,migration}/main.go`, `internal/workflow/apply` tests, `internal/platform`/output-capture tests, `tests/fixtures/`, `examples/`, `tests/integration/render-parity/main.go`.
+- **SemVer**: none. Commit types `test:` / `chore:`.
+- **Dependencies**: annotation + migration-idempotence steps need kind + CRDs (existing integration tier); everything else pure unit.

--- a/openspec/changes/test-coverage-and-fixture-hygiene/specs/test-fixture-lineage/spec.md
+++ b/openspec/changes/test-coverage-and-fixture-hygiene/specs/test-fixture-lineage/spec.md
@@ -1,0 +1,30 @@
+# test-fixture-lineage
+
+## Purpose
+
+Keeps the repo's fixtures and examples on the current published schema line and its tests free of sibling-checkout dependencies. (Test-infrastructure capability; precedent: `validation-gates`, `kind-cluster-tasks`, `ci-workflow`.)
+
+## ADDED Requirements
+
+### Requirement: Maintained fixtures track the current schema line
+
+Fixtures and examples consumed by tests or presented as current documentation SHALL import only the current published schema line (`opmodel.dev/core@v1` and current catalogs). Artifacts kept for the retired line SHALL live under an explicitly marked legacy location with a note naming the line they document, and SHALL NOT be consumed by any test.
+
+#### Scenario: No retired-schema imports outside legacy
+
+- **WHEN** the repo is grepped for retired-line imports (`core/v1alpha1`, `modulerelease@v1`, `opm/v1alpha1`) outside the marked legacy location
+- **THEN** there SHALL be no matches in fixtures, examples, or test inputs
+
+#### Scenario: Vet fixtures exercise current schema
+
+- **WHEN** the module vet tests run
+- **THEN** their fixtures SHALL be `core@v1`-line modules exercising the same behaviors (valid module, secrets discovery, debug values) as before the port
+
+### Requirement: Tests depend only on repo-local fixtures
+
+No test or integration program SHALL read fixtures from a sibling repository checkout. Vendored copies SHALL carry a provenance header naming their origin.
+
+#### Scenario: render-parity is self-contained
+
+- **WHEN** the render-parity program runs in a standalone clone of this repo (no sibling checkouts)
+- **THEN** it SHALL locate its module fixture under this repo's `tests/fixtures/` and proceed to the registry-gated comparison

--- a/openspec/changes/test-coverage-and-fixture-hygiene/tasks.md
+++ b/openspec/changes/test-coverage-and-fixture-hygiene/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: test-coverage-and-fixture-hygiene
+
+## 1. Live coverage additions (kind + CRDs; existing integration tier)
+
+- [ ] 1.1 `tests/integration/ssa-ownership/main.go`: new step pair — `ApplySpec` with `SourceLocal: true` → assert `module-instance.opmodel.dev/source: local` on the live object; re-apply with `false` → assert annotation removed by SSA (closes the open C1 VERIFICATION-NOTES item; 0006 D38 gate input)
+- [ ] 1.2 `tests/integration/migration/main.go`: idempotence scenario — CR present + leftover legacy Secret → apply → Secret deleted without being read as inventory, no duplicate migration, single clean end state
+
+## 2. Unit coverage additions
+
+- [ ] 2.1 Migration failure ordering: fake-client `PrependReactor` fails the status-subresource apply → assert legacy Secret retained and no delete action recorded (delete-after-status contract)
+- [ ] 2.2 `RunClusterGates` probe-order assertion (CRD presence → field floor → ceiling) via reactor-recorded probe sequence
+- [ ] 2.3 Dry-run exemption: dry-run `Execute` against a CRD-less fake → succeeds with zero gate probes recorded
+- [ ] 2.4 Platform-fallback banner: capture output during apply-path resolution with failing cluster getter → assert the D21 provenance warning is emitted (add a test-only writer seam in `internal/output` only if none exists; keep minimal)
+
+## 3. Fixture hygiene
+
+- [ ] 3.1 Vendor `podinfo` module fixture from opm-operator into `tests/fixtures/modules/podinfo` with provenance header; point `tests/integration/render-parity/main.go` at it (drop the `../opm-operator` path)
+- [ ] 3.2 Port `tests/fixtures/valid/{simple-module,secrets-module,module-with-debug-values}` to the `core@v1` line; vet tests keep asserting the same behaviors
+- [ ] 3.3 Examples disposition: port `examples/instances/jellyfin` to `core@v1` `#ModuleInstance` form; verify garage / mc_java_fleet module availability on the v1 line — port where available, else move to `examples/legacy/` with a README naming the retired line; `examples/cue.mod` follows
+- [ ] 3.4 Verify `examples/modules/mc_router` (mod_build_test's fixture) against the current line; port or swap the test to a v1-line module
+- [ ] 3.5 Lineage grep gate: no `core/v1alpha1` / `modulerelease@v1` / `opm/v1alpha1` imports outside `examples/legacy/`
+- [ ] 3.6 OPTIONAL: consolidate the duplicated integration-program helpers into a shared package under `tests/integration/` (skip without guilt on any friction)
+
+## 4. Verification
+
+- [ ] 4.1 `task check` green; `task test:integration` green on kind (ssa-ownership + migration new steps executing); render-parity runs standalone
+- [ ] 4.2 Sync/archive per openspec flow


### PR DESCRIPTION
Drafts the test/fixture OpenSpec change from the 2026-07-21 fixture audit: live provenance-annotation SSA-clear step (open C1 VERIFICATION-NOTES item), migration failure/idempotence coverage at the correct tiers, gate-order/dry-run/banner unit assertions, and fixture-lineage hygiene (core@v1 port, vendored podinfo, legacy retirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)