### PR TITLE
build(deps): bump library to v1.0.0-alpha.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/log v1.0.0
 	github.com/gonvenience/ytbx v1.5.0
 	github.com/homeport/dyff v1.12.0
-	github.com/open-platform-model/library v1.0.0-alpha.7
+	github.com/open-platform-model/library v1.0.0-alpha.8
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
 github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
-github.com/open-platform-model/library v1.0.0-alpha.7 h1:liXpK1Bg6KC3l3ZOD/J2Nzx8uwomteJoRJZfvZYOv8E=
-github.com/open-platform-model/library v1.0.0-alpha.7/go.mod h1:QC5O4LXr9yz1tPa5Z21Dt3HcQ+lofN9KCyPml6qSHns=
+github.com/open-platform-model/library v1.0.0-alpha.8 h1:UzO/fcbzOvG6EhE4LUHgk9dwNhEuY/X9/F8OvR4XGw4=
+github.com/open-platform-model/library v1.0.0-alpha.8/go.mod h1:QC5O4LXr9yz1tPa5Z21Dt3HcQ+lofN9KCyPml6qSHns=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=


### PR DESCRIPTION
Bumps the embedded OPM kernel dependency `github.com/open-platform-model/library` from `v1.0.0-alpha.7` → `v1.0.0-alpha.8` (latest released alpha).

`go build ./...` and the unit suite pass locally against alpha.8.

> Note: `build(deps)` is a non-releasing commit type, so this won't cut a new cli release on merge. Say the word if you'd like it as `fix(deps):` to ship alpha.8's kernel changes in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
