### PR TITLE
perf(cli): remove client-side api throttling and redundant listings

### DIFF
--- a/internal/inventory/discover.go
+++ b/internal/inventory/discover.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"context"
+	"sync"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,6 +12,11 @@ import (
 	"github.com/open-platform-model/cli/internal/kubernetes"
 	"github.com/open-platform-model/cli/internal/output"
 )
+
+// discoverConcurrency bounds the in-flight GETs issued for a single instance's
+// inventory. Large instances (CRD-heavy platform modules) carry 50+ entries, so
+// fetching them serially made one instance dominate the whole command's latency.
+const discoverConcurrency = 8
 
 // DiscoverResourcesFromInventory fetches the live state of each resource
 // tracked in the inventory. It performs one targeted GET per entry
@@ -26,28 +32,56 @@ func DiscoverResourcesFromInventory(ctx context.Context, client *kubernetes.Clie
 
 	entries := inv.Inventory.Entries
 
-	for _, entry := range entries {
-		gvr := schema.GroupVersionResource{
-			Group:    entry.Group,
-			Version:  entry.Version,
-			Resource: kubernetes.KindToResource(entry.Kind),
-		}
+	// Fetch entries concurrently. Results are collected by index so that live
+	// and missing keep inventory order regardless of completion order.
+	type entryResult struct {
+		obj     *unstructured.Unstructured
+		missing bool
+	}
+	results := make([]entryResult, len(entries))
 
-		obj, getErr := client.ResourceClient(gvr, entry.Namespace).Get(ctx, entry.Name, metav1.GetOptions{})
-		if getErr != nil {
-			if apierrors.IsNotFound(getErr) {
-				missing = append(missing, entry)
-				output.Debug("inventory resource missing from cluster",
-					"kind", entry.Kind, "namespace", entry.Namespace, "name", entry.Name)
-				continue
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, discoverConcurrency)
+
+	for i, entry := range entries {
+		wg.Add(1)
+		go func(idx int, entry InventoryEntry) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			gvr := schema.GroupVersionResource{
+				Group:    entry.Group,
+				Version:  entry.Version,
+				Resource: kubernetes.KindToResource(entry.Kind),
 			}
-			// Other errors — log and skip (don't treat as missing)
-			output.Debug("could not fetch inventory resource",
-				"kind", entry.Kind, "name", entry.Name, "err", getErr)
-			continue
-		}
 
-		live = append(live, obj)
+			obj, getErr := client.ResourceClient(gvr, entry.Namespace).Get(ctx, entry.Name, metav1.GetOptions{})
+			if getErr != nil {
+				if apierrors.IsNotFound(getErr) {
+					results[idx] = entryResult{missing: true}
+					output.Debug("inventory resource missing from cluster",
+						"kind", entry.Kind, "namespace", entry.Namespace, "name", entry.Name)
+					return
+				}
+				// Other errors — log and skip (don't treat as missing)
+				output.Debug("could not fetch inventory resource",
+					"kind", entry.Kind, "name", entry.Name, "err", getErr)
+				return
+			}
+
+			results[idx] = entryResult{obj: obj}
+		}(i, entry)
+	}
+	wg.Wait()
+
+	for i, r := range results {
+		switch {
+		case r.missing:
+			missing = append(missing, entries[i])
+		case r.obj != nil:
+			live = append(live, r.obj)
+		}
 	}
 
 	return live, missing, nil

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -162,5 +162,29 @@ func buildRestConfig(opts ClientOptions) (*rest.Config, error) {
 		overrides,
 	)
 
-	return clientConfig.ClientConfig()
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// client-go defaults to QPS=5/Burst=10. Read-heavy commands issue one GET
+	// per inventory entry, so that token bucket — not the API server — sets the
+	// command's latency: `instance list -A` over 176 entries took 33s, almost
+	// exactly the (176-10)/5 the limiter permits. A negative QPS disables the
+	// client-side limiter (see rest.RESTClientForConfigAndClient, which only
+	// installs one when qps > 0), which is what kubectl does: servers have
+	// enforced API Priority and Fairness since 1.29, so client-side throttling
+	// is redundant back pressure. Real back pressure comes from the bounded
+	// worker pools at the call sites, which cap concurrent in-flight requests.
+	//
+	// Only defaults are overridden — an explicit QPS/Burst from the kubeconfig
+	// or a caller-supplied rest.Config still wins.
+	if restConfig.QPS == 0 {
+		restConfig.QPS = -1
+	}
+	if restConfig.Burst == 0 {
+		restConfig.Burst = -1
+	}
+
+	return restConfig, nil
 }

--- a/internal/kubernetes/tree.go
+++ b/internal/kubernetes/tree.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,6 +20,74 @@ import (
 
 // noComponentLabel is the placeholder used for resources missing a component mapping.
 const noComponentLabel = "(no component)"
+
+// listCache memoizes the namespace-scoped Pod and ReplicaSet listings that
+// ownership walking depends on. Every walk asks for the same unfiltered listing
+// of a namespace and filters by owner UID client-side, so without memoization a
+// component with N workloads issues N identical full-namespace LISTs — each one
+// transferring every Pod in the namespace. One build reuses a single listing per
+// (kind, namespace).
+//
+// A nil *listCache is valid and simply performs uncached listings, which keeps
+// the walk functions usable on their own.
+type listCache struct {
+	mu          sync.Mutex
+	pods        map[string][]corev1.Pod
+	replicaSets map[string][]appsv1.ReplicaSet
+}
+
+func newListCache() *listCache {
+	return &listCache{
+		pods:        make(map[string][]corev1.Pod),
+		replicaSets: make(map[string][]appsv1.ReplicaSet),
+	}
+}
+
+// podsIn returns every Pod in ns, listing it at most once per cache.
+func (c *listCache) podsIn(ctx context.Context, client *Client, ns string) ([]corev1.Pod, error) {
+	if c == nil {
+		list, err := client.Clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return list.Items, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cached, ok := c.pods[ns]; ok {
+		return cached, nil
+	}
+	list, err := client.Clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	c.pods[ns] = list.Items
+	return list.Items, nil
+}
+
+// replicaSetsIn returns every ReplicaSet in ns, listing it at most once per cache.
+func (c *listCache) replicaSetsIn(ctx context.Context, client *Client, ns string) ([]appsv1.ReplicaSet, error) {
+	if c == nil {
+		list, err := client.Clientset.AppsV1().ReplicaSets(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return list.Items, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cached, ok := c.replicaSets[ns]; ok {
+		return cached, nil
+	}
+	list, err := client.Clientset.AppsV1().ReplicaSets(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	c.replicaSets[ns] = list.Items
+	return list.Items, nil
+}
 
 // displayKind returns an abbreviated kind name for terminal display.
 // PersistentVolumeClaim is shortened to PVC to keep tree lines compact.
@@ -138,6 +207,11 @@ func GetModuleTree(ctx context.Context, client *Client, opts TreeOptions) (*Tree
 func BuildTree(ctx context.Context, client *Client, opts TreeOptions) *TreeResult {
 	result := &TreeResult{Instance: opts.InstanceInfo}
 
+	// One cache per build: ownership walking re-lists the same namespaces once
+	// per workload, and a tree is a point-in-time view, so a single listing per
+	// namespace is both cheaper and more internally consistent.
+	cache := newListCache()
+
 	groups := groupByComponent(opts.InventoryLive, opts.ComponentMap)
 	for _, compName := range sortedComponentNames(groups) {
 		resources := groups[compName]
@@ -148,7 +222,7 @@ func BuildTree(ctx context.Context, client *Client, opts TreeOptions) *TreeResul
 
 		if opts.Depth >= 1 {
 			for _, res := range resources {
-				comp.Resources = append(comp.Resources, buildResourceNode(ctx, client, res, opts.Depth))
+				comp.Resources = append(comp.Resources, buildResourceNode(ctx, client, res, opts.Depth, cache))
 			}
 		}
 
@@ -160,7 +234,7 @@ func BuildTree(ctx context.Context, client *Client, opts TreeOptions) *TreeResul
 }
 
 // buildResourceNode constructs a ResourceNode for a single live unstructured resource.
-func buildResourceNode(ctx context.Context, client *Client, res *unstructured.Unstructured, depth int) ResourceNode {
+func buildResourceNode(ctx context.Context, client *Client, res *unstructured.Unstructured, depth int, cache *listCache) ResourceNode {
 	node := ResourceNode{
 		Kind:      res.GetKind(),
 		Name:      res.GetName(),
@@ -169,7 +243,7 @@ func buildResourceNode(ctx context.Context, client *Client, res *unstructured.Un
 		Replicas:  getReplicaCount(res),
 	}
 	if depth >= 2 {
-		node.Children = walkOwnership(ctx, client, res)
+		node.Children = walkOwnership(ctx, client, res, cache)
 	}
 	return node
 }
@@ -284,26 +358,26 @@ func getReplicaCount(res *unstructured.Unstructured) string {
 // Only Deployment, StatefulSet, DaemonSet, and Job produce children.
 // On any API error the resource is returned without children and the error is
 // logged at DEBUG level (graceful degradation).
-func walkOwnership(ctx context.Context, client *Client, res *unstructured.Unstructured) []ResourceNode {
+func walkOwnership(ctx context.Context, client *Client, res *unstructured.Unstructured, cache *listCache) []ResourceNode {
 	switch res.GetKind() {
 	case kindDeployment:
-		return walkDeployment(ctx, client, res)
+		return walkDeployment(ctx, client, res, cache)
 	case kindStatefulSet:
-		return walkStatefulSet(ctx, client, res)
+		return walkStatefulSet(ctx, client, res, cache)
 	case kindDaemonSet:
-		return walkDaemonSet(ctx, client, res)
+		return walkDaemonSet(ctx, client, res, cache)
 	case kindJob:
-		return walkJob(ctx, client, res)
+		return walkJob(ctx, client, res, cache)
 	}
 	return nil
 }
 
 // walkDeployment returns ReplicaSet nodes, each with their Pod children.
-func walkDeployment(ctx context.Context, client *Client, res *unstructured.Unstructured) []ResourceNode {
+func walkDeployment(ctx context.Context, client *Client, res *unstructured.Unstructured, cache *listCache) []ResourceNode {
 	ns := res.GetNamespace()
 	uid := res.GetUID()
 
-	rsList, err := client.Clientset.AppsV1().ReplicaSets(ns).List(ctx, metav1.ListOptions{})
+	replicaSets, err := cache.replicaSetsIn(ctx, client, ns)
 	if err != nil {
 		output.Debug("failed to list replicasets",
 			"deployment", res.GetName(), "namespace", ns, "error", err)
@@ -311,8 +385,8 @@ func walkDeployment(ctx context.Context, client *Client, res *unstructured.Unstr
 	}
 
 	var nodes []ResourceNode
-	for i := range rsList.Items {
-		rs := &rsList.Items[i]
+	for i := range replicaSets {
+		rs := &replicaSets[i]
 		if !hasOwnerWithUID(rs.OwnerReferences, uid) {
 			continue
 		}
@@ -322,7 +396,7 @@ func walkDeployment(ctx context.Context, client *Client, res *unstructured.Unstr
 			Namespace: rs.Namespace,
 			Status:    replicaSetHealth(rs),
 			Replicas:  pluralPods(int64(rs.Status.Replicas)),
-			Children:  walkReplicaSet(ctx, client, rs),
+			Children:  walkReplicaSet(ctx, client, rs, cache),
 		}
 		nodes = append(nodes, node)
 	}
@@ -332,8 +406,8 @@ func walkDeployment(ctx context.Context, client *Client, res *unstructured.Unstr
 }
 
 // walkReplicaSet returns Pod nodes owned by a ReplicaSet.
-func walkReplicaSet(ctx context.Context, client *Client, rs *appsv1.ReplicaSet) []ResourceNode {
-	podList, err := client.Clientset.CoreV1().Pods(rs.Namespace).List(ctx, metav1.ListOptions{})
+func walkReplicaSet(ctx context.Context, client *Client, rs *appsv1.ReplicaSet, cache *listCache) []ResourceNode {
+	pods, err := cache.podsIn(ctx, client, rs.Namespace)
 	if err != nil {
 		output.Debug("failed to list pods",
 			"replicaset", rs.Name, "namespace", rs.Namespace, "error", err)
@@ -342,8 +416,8 @@ func walkReplicaSet(ctx context.Context, client *Client, rs *appsv1.ReplicaSet) 
 
 	uid := rs.UID
 	var nodes []ResourceNode
-	for i := range podList.Items {
-		pod := &podList.Items[i]
+	for i := range pods {
+		pod := &pods[i]
 		if !hasOwnerWithUID(pod.OwnerReferences, uid) {
 			continue
 		}
@@ -355,34 +429,34 @@ func walkReplicaSet(ctx context.Context, client *Client, rs *appsv1.ReplicaSet) 
 }
 
 // walkStatefulSet returns Pod nodes directly owned by a StatefulSet (no RS layer).
-func walkStatefulSet(ctx context.Context, client *Client, res *unstructured.Unstructured) []ResourceNode {
+func walkStatefulSet(ctx context.Context, client *Client, res *unstructured.Unstructured, cache *listCache) []ResourceNode {
 	return walkPodsOwnedBy(ctx, client, res.GetNamespace(), res.GetUID(),
-		"statefulset", res.GetName())
+		"statefulset", res.GetName(), cache)
 }
 
 // walkDaemonSet returns Pod nodes owned by a DaemonSet.
-func walkDaemonSet(ctx context.Context, client *Client, res *unstructured.Unstructured) []ResourceNode {
+func walkDaemonSet(ctx context.Context, client *Client, res *unstructured.Unstructured, cache *listCache) []ResourceNode {
 	return walkPodsOwnedBy(ctx, client, res.GetNamespace(), res.GetUID(),
-		"daemonset", res.GetName())
+		"daemonset", res.GetName(), cache)
 }
 
 // walkJob returns Pod nodes owned by a Job.
-func walkJob(ctx context.Context, client *Client, res *unstructured.Unstructured) []ResourceNode {
+func walkJob(ctx context.Context, client *Client, res *unstructured.Unstructured, cache *listCache) []ResourceNode {
 	return walkPodsOwnedBy(ctx, client, res.GetNamespace(), res.GetUID(),
-		"job", res.GetName())
+		"job", res.GetName(), cache)
 }
 
 // walkPodsOwnedBy lists all Pods in ns and returns those owned by the given uid.
-func walkPodsOwnedBy(ctx context.Context, client *Client, ns string, uid types.UID, kind, name string) []ResourceNode {
-	podList, err := client.Clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+func walkPodsOwnedBy(ctx context.Context, client *Client, ns string, uid types.UID, kind, name string, cache *listCache) []ResourceNode {
+	pods, err := cache.podsIn(ctx, client, ns)
 	if err != nil {
 		output.Debug("failed to list pods", kind, name, "namespace", ns, "error", err)
 		return nil
 	}
 
 	var nodes []ResourceNode
-	for i := range podList.Items {
-		pod := &podList.Items[i]
+	for i := range pods {
+		pod := &pods[i]
 		if !hasOwnerWithUID(pod.OwnerReferences, uid) {
 			continue
 		}

--- a/internal/kubernetes/tree_test.go
+++ b/internal/kubernetes/tree_test.go
@@ -1023,12 +1023,15 @@ func countListActions(t *testing.T, client *Client, resource string) int {
 func TestBuildTree_ReusesNamespaceListingsAcrossWorkloads(t *testing.T) {
 	ctx := context.Background()
 
-	var objects []runtime.Object
-	var live []*unstructured.Unstructured
+	// Four DaemonSets in one namespace: without reuse this is four pod LISTs.
+	daemonSets := []string{"agent-a", "agent-b", "agent-c", "agent-d"}
+
+	// +1 for the Deployment below and the ReplicaSet backing it.
+	objects := make([]runtime.Object, 0, len(daemonSets)+1)
+	live := make([]*unstructured.Unstructured, 0, len(daemonSets)+1)
 	componentMap := map[string]string{}
 
-	// Four DaemonSets in one namespace: without reuse this is four pod LISTs.
-	for _, name := range []string{"agent-a", "agent-b", "agent-c", "agent-d"} {
+	for _, name := range daemonSets {
 		ds := makeRes("DaemonSet", "default", name)
 		live = append(live, ds)
 		componentMap["DaemonSet/default/"+name] = "agents"

--- a/internal/kubernetes/tree_test.go
+++ b/internal/kubernetes/tree_test.go
@@ -207,7 +207,7 @@ func TestWalkDeployment_ReturnsRSAndPods(t *testing.T) {
 	deploy := makeRes("Deployment", "default", "web")
 	deploy.SetUID(deployUID)
 
-	children := walkDeployment(ctx, client, deploy)
+	children := walkDeployment(ctx, client, deploy, newListCache())
 	require.Len(t, children, 1)
 	assert.Equal(t, "ReplicaSet", children[0].Kind)
 	assert.Equal(t, "web-rs-abc", children[0].Name)
@@ -242,7 +242,7 @@ func TestWalkDeployment_OldRSWithZeroPods(t *testing.T) {
 	deploy := makeRes("Deployment", "default", "web")
 	deploy.SetUID(deployUID)
 
-	children := walkDeployment(ctx, client, deploy)
+	children := walkDeployment(ctx, client, deploy, newListCache())
 	require.Len(t, children, 1)
 	assert.Equal(t, HealthReady, children[0].Status, "RS with 0 replicas should be Ready")
 	assert.Equal(t, "0 pods", children[0].Replicas)
@@ -272,7 +272,7 @@ func TestWalkStatefulSet_ReturnsPods(t *testing.T) {
 	ss := makeRes("StatefulSet", "default", "db")
 	ss.SetUID(ssUID)
 
-	children := walkStatefulSet(ctx, client, ss)
+	children := walkStatefulSet(ctx, client, ss, newListCache())
 	require.Len(t, children, 1)
 	assert.Equal(t, "Pod", children[0].Kind)
 	assert.Equal(t, "db-0", children[0].Name)
@@ -305,7 +305,7 @@ func TestWalkOwnership_IgnoresUnownedPods(t *testing.T) {
 	deploy := makeRes("Deployment", "default", "web")
 	deploy.SetUID(deployUID)
 
-	children := walkDeployment(ctx, client, deploy)
+	children := walkDeployment(ctx, client, deploy, newListCache())
 	assert.Empty(t, children)
 }
 
@@ -315,7 +315,7 @@ func TestWalkOwnership_PassiveResourceReturnsNil(t *testing.T) {
 
 	for _, kind := range []string{"Service", "ConfigMap", "Ingress", "PersistentVolumeClaim"} {
 		res := makeRes(kind, "ns", "r")
-		children := walkOwnership(ctx, client, res)
+		children := walkOwnership(ctx, client, res, newListCache())
 		assert.Nil(t, children, "passive resource %s should have no children", kind)
 	}
 }
@@ -995,4 +995,90 @@ func TestFormatPlainTree_PVCAbbreviated(t *testing.T) {
 	assert.NotContains(t, out, "PersistentVolumeClaim/data", "full kind should not appear in terminal output")
 	assert.Contains(t, out, "Bound")
 	assert.Contains(t, out, "10Gi")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section 6: Namespace listing reuse
+// ─────────────────────────────────────────────────────────────────────────────
+
+// countListActions returns how many LIST calls the fake clientset recorded for
+// the given resource.
+func countListActions(t *testing.T, client *Client, resource string) int {
+	t.Helper()
+	fakeClient, ok := client.Clientset.(*fake.Clientset)
+	require.True(t, ok, "expected a fake clientset")
+
+	n := 0
+	for _, a := range fakeClient.Actions() {
+		if a.GetVerb() == "list" && a.GetResource().Resource == resource {
+			n++
+		}
+	}
+	return n
+}
+
+// Ownership walking filters a full namespace listing by owner UID, so every
+// workload used to trigger its own identical LIST. One build must reuse a single
+// listing per namespace no matter how many workloads it contains.
+func TestBuildTree_ReusesNamespaceListingsAcrossWorkloads(t *testing.T) {
+	ctx := context.Background()
+
+	var objects []runtime.Object
+	var live []*unstructured.Unstructured
+	componentMap := map[string]string{}
+
+	// Four DaemonSets in one namespace: without reuse this is four pod LISTs.
+	for _, name := range []string{"agent-a", "agent-b", "agent-c", "agent-d"} {
+		ds := makeRes("DaemonSet", "default", name)
+		live = append(live, ds)
+		componentMap["DaemonSet/default/"+name] = "agents"
+		objects = append(objects, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name + "-pod",
+				Namespace:       "default",
+				OwnerReferences: []metav1.OwnerReference{{UID: ds.GetUID()}},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		})
+	}
+
+	// A Deployment adds a ReplicaSet layer, which lists pods again.
+	deploy := makeRes("Deployment", "default", "web")
+	live = append(live, deploy)
+	componentMap["Deployment/default/web"] = "web"
+	objects = append(objects, &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "web-rs",
+			Namespace:       "default",
+			UID:             types.UID("web-rs-uid"),
+			OwnerReferences: []metav1.OwnerReference{{UID: deploy.GetUID()}},
+		},
+		Status: appsv1.ReplicaSetStatus{Replicas: 1, ReadyReplicas: 1},
+	})
+
+	client := makeTreeClient(objects...)
+	result := BuildTree(ctx, client, TreeOptions{
+		InventoryLive: live,
+		ComponentMap:  componentMap,
+		Depth:         2,
+	})
+
+	// The tree itself must still be complete.
+	require.Len(t, result.Components, 2)
+	var daemonSetsWithPods int
+	for _, comp := range result.Components {
+		for _, res := range comp.Resources {
+			if res.Kind == "DaemonSet" {
+				assert.Len(t, res.Children, 1, "daemonset %s lost its pod", res.Name)
+				daemonSetsWithPods++
+			}
+		}
+	}
+	assert.Equal(t, 4, daemonSetsWithPods)
+
+	// Five workloads, but each namespace is listed exactly once.
+	assert.Equal(t, 1, countListActions(t, client, "pods"),
+		"pods should be listed once per namespace, not once per workload")
+	assert.Equal(t, 1, countListActions(t, client, "replicasets"),
+		"replicasets should be listed once per namespace")
 }


### PR DESCRIPTION
## Problem

`opm instance list -A` took 33s against a 12-instance cluster. `tree` and `status` were
similarly slow on large modules (~9s for a 53-resource instance).

The cluster was never the bottleneck. `buildRestConfig` never set `QPS`/`Burst`, so
client-go applied its defaults — **QPS=5, Burst=10**. Since these commands issue one GET
per inventory entry, that token bucket alone set the command's latency:

```
(176 entries - 10 burst) / 5 per sec = 33.2s  predicted
                                       33.4s  measured
```

Confirmed by scope, where the throttle engages only once a command exceeds the burst:

| Scope | Entries | Predicted | Measured |
| --- | --- | --- | --- |
| `-n jellyfin` | 5 (under burst) | ~0s | **0.071s** |
| `-n nzb` | 16 | 1.2s | 2.2s |
| `-n istio-system` | 53 | 8.6s | **8.8s** |
| `-A` | 176 | 33.2s | **33.4s** |

## Changes

- **`perf(k8s)`** — set `QPS=-1`, which disables the client-side limiter (`rest` only
  installs one when `qps > 0`). This is what kubectl does: servers have enforced API
  Priority and Fairness since 1.29, so client-side throttling is redundant back pressure.
  Real back pressure comes from the bounded worker pools at the call sites. Only defaults
  are overridden, so an explicit kubeconfig value still wins. Affects every cluster-facing
  command, not just the instance query group.
- **`perf(inventory)`** — `DiscoverResourcesFromInventory` fetched entries serially, so one
  large instance set the floor for the whole command. Now bounded-concurrent (8), with
  results collected by index so `live`/`missing` keep inventory order.
- **`perf(tree)`** — separate N+1: `walkPodsOwnedBy` listed *every pod in the namespace*
  and filtered client-side by owner UID, once per workload. A per-build cache reuses one
  listing per (kind, namespace).

Both of the first two changes are needed. Measured with a finite `QPS=50`, the added
concurrency buys **nothing** — 1.58s serial, 1.58s parallel — because at any finite QPS
the token bucket, not concurrency, is binding.

## Results

Measured against a live cluster. All output byte-identical to `v1.0.0-alpha.6`.

| Command | Before | After | |
| --- | --- | --- | --- |
| `instance list -A` (176 entries) | 33.42s | **0.20s** | 167x |
| `instance tree` istio (53) | 8.87s | **0.18s** | 49x |
| `instance tree` cert-manager (42) | 6.69s | **0.15s** | 45x |
| `instance status` istio (53) | 8.82s | **0.13s** | 68x |
| `instance status` metallb (24) | 3.02s | **0.07s** | 43x |

The `tree` cache contributes nothing measurable at this scale — istio has 3 workloads, so
it cuts 4 API calls to 2. It is worth keeping because it removes a scaling cliff (its cost
grows with namespace size, not instance size), not because it moved these numbers. Since
it is invisible in wall-clock, it is covered by a test that counts API calls on the fake
clientset (5 workloads must produce exactly 1 pod LIST); that test was verified to fail
against the pre-fix behaviour.

## Verification

- Full unit suite passes under `-race`; `go vet` clean.
- Lint clean (0 issues) under golangci-lint v2.11.3, the version CI pins.
- Output diffed against the released binary for `list -A`, `tree`, and `status` across five
  instances — identical in every case, including resource ordering.

## Follow-ups (not in this PR)

- `instanceListConcurrency = 5` was almost certainly chosen to match the old QPS=5 and is
  now an arbitrary cap.
- The `status`/`tree` walk is still sequential across components; the `listCache` mutex is
  already in place to allow parallelizing it.

