### PR TITLE
chore(openspec): deny delivery-operation tasks in tasks.md

### DIFF
--- a/.claude/skills/openspec-verify-change/SKILL.md
+++ b/.claude/skills/openspec-verify-change/SKILL.md
@@ -61,6 +61,11 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
      - Add CRITICAL issue for each incomplete task
      - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
 
+   **Task Hygiene**:
+   - Flag any task that is a delivery operation rather than implementation or verification: committing, pushing, branching, opening/merging PRs, tagging, cutting releases, commit-message or PR-body hygiene checks
+   - Add WARNING: "Delivery-operation task: <description> — remove it rather than checking it off; delivery happens after implementation under the repo's normal git workflow"
+   - Exception: skip this check when the change's stated deliverable is itself a release or publishing operation — there those steps are the implementation
+
    **Spec Coverage**:
    - If delta specs exist in `openspec/changes/<name>/specs/`:
      - Extract all requirements (marked with "### Requirement:")

--- a/.opencode/skills/openspec-verify-change/SKILL.md
+++ b/.opencode/skills/openspec-verify-change/SKILL.md
@@ -60,6 +60,11 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
      - Add CRITICAL issue for each incomplete task
      - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
 
+   **Task Hygiene**:
+   - Flag any task that is a delivery operation rather than implementation or verification: committing, pushing, branching, opening/merging PRs, tagging, cutting releases, commit-message or PR-body hygiene checks
+   - Add WARNING: "Delivery-operation task: <description> — remove it rather than checking it off; delivery happens after implementation under the repo's normal git workflow"
+   - Exception: skip this check when the change's stated deliverable is itself a release or publishing operation — there those steps are the implementation
+
    **Spec Coverage**:
    - If delta specs exist in `openspec/changes/<name>/specs/`:
      - Extract all requirements (marked with "### Requirement:")

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -150,3 +150,9 @@ rules:
     - Group implementation tasks by package
     - Include validation gates as final tasks (task lint, task test)
     - Include integration test tasks where K8s interaction is involved
+    - "NEVER include delivery operations as tasks: no committing, pushing, branching,
+      opening or merging PRs, tagging, cutting releases, and no commit-message or PR-body
+      hygiene checks. tasks.md covers implementation and verification only — delivery
+      happens afterwards under the repo's normal git workflow and needs no spelling out.
+      Sole exception: a change whose stated deliverable is itself a release or publishing
+      operation; there those steps ARE the implementation."


### PR DESCRIPTION
Adds an explicit rule to the OpenSpec `tasks` artifact rules in `openspec/config.yaml`: delivery operations (committing, pushing, branching, opening/merging PRs, tagging, cutting releases, commit-message hygiene checks) must never appear as tasks in `tasks.md`. Tasks cover implementation and verification only; delivery happens afterwards under the repo's normal git workflow. Sole exception: a change whose stated deliverable is itself a release or publishing operation.

Also adds a Task Hygiene check to the `openspec-verify-change` skill so delivery-operation tasks in existing changes are flagged as warnings at verify time.

Applied consistently across all OPM repos with an OpenSpec workflow.
