### PR TITLE
feat(publish): identity-driven publish pipeline for modules and catalogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,11 @@ Read when entering `cli/`:
 
 - `adr/` - Architecture Decision Records
 - `cmd/opm/` - CLI entrypoint + root command wiring.
-- `internal/cmd/` - Cobra command implementations.
+- `internal/cmd/` - Cobra command implementations (command groups: `module`, `catalog`, `instance`, `config`, `operator`).
 - `internal/cmdutil/` - shared flags, annotations, command-facing helpers.
 - `internal/config/` - config resolution, schema validation, defaults.
+- `internal/publish/` - identity-driven publish pipeline (enhancement 0011): gates, refusal catalog, plan/dry-run, registry lookup + push; also the vet-shared identity/coordinate checks.
+- `internal/cueedit/` - surgical identity-file rewrites (D8's schema-fixed-path `Version` write; used by `publish --version`, reused by `version set`).
 - `internal/kubernetes/` - cluster ops, status, apply, delete, events.
 - `internal/output/` - terminal formatting, log output, tables, manifests.
 - `internal/instancefile/` - instance file detection + loading.

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@
 - [ ] Add "opm mod list". It should list all modules in the defined namespace (default ns is, default). "-A" should list in all namespaces.
   - Note: Can now leverage `instance-id` labels for discovery (see deterministic-release-identity).
 - [ ] Add check during processing: Check if a module author has referenced "values" and not "#config" in a component. This will not work and should warn the user.
-  - This can be utilized with the future "opm mod publish" command, so that an author cannot publish a module that is not valid.
+  - `opm module publish` exists now (cli-publish-pipeline); this warning could land as a publish gate in `internal/publish/gates.go`, so an author cannot publish a module that is not valid.
 - [x] ~~"opm mod delete --name blog --namespace default --verbose" proceeds but with no change, 0 resources deleted. We should add validation to first look for the module and inform the caller if not found.~~
   - **Resolved:** Implemented in `refine-resource-discovery` change. Commands now return `NoResourcesFoundError` when no resources match the selector.
 - [x] ~~Add a flag to "opm mod apply" that will create the namespace if missing.~~

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,9 +79,9 @@ M1: CLI Stability & Validation
  │
  ├──► M3: Distribution
  │     │
- │     ├── distribution-v1
+ │     ├── cli-publish-pipeline ··· (done)
  │     └── templates-v2
- │           └──► distribution-v1
+ │           └──► cli-publish-pipeline
  │
  └──► M4: Rendering Pipeline Maturity
        │
@@ -136,7 +136,7 @@ OCI-native module distribution — the ability to publish, discover, and consume
 
 **Major deliverables:**
 
-- **Module distribution** — `opm module publish` (push module to OCI registry), `opm module get` (pull module), `opm module update` (update dependencies), `opm module tidy` (tidy CUE module dependencies without the external `cue` binary). Uses oras-go for OCI, Docker `config.json` for auth. Strict SemVer only — no `@latest`. *(openspec change: distribution-v1)*
+- **Module distribution** — `opm module publish` and `opm catalog publish` landed as the identity-driven pipeline of enhancement 0011 (`internal/publish`): coordinates derive from the artifact's own `identity/identity.cue`, gates refuse in the fixed condition → evidence → consequence → action shape, the plan doubles as the dry run, and the push goes through CUE's own module machinery (`modzip` + `modregistry` via `modconfig`'s resolver — Docker `config.json` auth arrives through the same chain reads use; no oras-go). Strict SemVer only — no `@latest`. *(openspec change: cli-publish-pipeline; still open here: `opm module get` / `update` / `tidy`)*
 
 - **Template distribution** — `opm template list`, `get`, `show`, `validate`, `publish`. Replaces the V1 embedded templates with registry-distributed templates. V1 templates remain during transition. *(openspec change: templates-v2)*
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/open-platform-model/cli
 go 1.26.0
 
 require (
+	cuelabs.dev/go/oci/ociregistry v0.0.0-20260601085548-328ff8e2c943
 	cuelang.org/go v0.17.1
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v1.0.0
@@ -19,7 +20,6 @@ require (
 )
 
 require (
-	cuelabs.dev/go/oci/ociregistry v0.0.0-20260601085548-328ff8e2c943 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -85,6 +85,7 @@ require (
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
+	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/cmd/catalog/catalog.go
+++ b/internal/cmd/catalog/catalog.go
@@ -1,0 +1,25 @@
+// Package catalogcmd provides CLI command implementations for the catalog
+// command group.
+package catalogcmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-platform-model/cli/internal/config"
+)
+
+// NewCatalogCmd creates the catalog command group.
+func NewCatalogCmd(cfg *config.GlobalConfig) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "catalog",
+		Short: "Work with catalog source",
+		Long: `Work with OPM catalogs.
+
+		Use this command group when you are starting from catalog source: publish a
+		catalog release from its committed tree.`,
+	}
+
+	c.AddCommand(NewCatalogPublishCmd(cfg))
+
+	return c
+}

--- a/internal/cmd/catalog/catalog_test.go
+++ b/internal/cmd/catalog/catalog_test.go
@@ -1,0 +1,38 @@
+package catalogcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-platform-model/cli/internal/config"
+)
+
+func TestNewCatalogCmd(t *testing.T) {
+	cmd := NewCatalogCmd(&config.GlobalConfig{})
+
+	assert.Equal(t, "catalog", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, c := range cmd.Commands() {
+		names = append(names, c.Name())
+	}
+	assert.Contains(t, names, "publish")
+}
+
+func TestNewCatalogPublishCmd(t *testing.T) {
+	cmd := NewCatalogPublishCmd(&config.GlobalConfig{})
+
+	assert.Equal(t, "publish [path]", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+
+	require.NotNil(t, cmd.Flags().Lookup("version"))
+	require.NotNil(t, cmd.Flags().Lookup("dry-run"))
+	// A catalog has no override waiver: its dependency divergence propagates
+	// into the key space of everything built against it.
+	assert.Nil(t, cmd.Flags().Lookup("skip-override-check"))
+}

--- a/internal/cmd/catalog/publish.go
+++ b/internal/cmd/catalog/publish.go
@@ -1,0 +1,54 @@
+package catalogcmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-platform-model/cli/internal/cmdutil"
+	"github.com/open-platform-model/cli/internal/config"
+	"github.com/open-platform-model/cli/internal/publish"
+)
+
+// NewCatalogPublishCmd creates the catalog publish command.
+//
+// Unlike module publish there is no --skip-override-check: a catalog's
+// dependency divergence propagates into the key space of every module built
+// against it, so a tree carrying cue.mod/local-module.cue always refuses.
+func NewCatalogPublishCmd(cfg *config.GlobalConfig) *cobra.Command {
+	var flags cmdutil.PublishFlags
+
+	c := &cobra.Command{
+		Use:   "publish [path]",
+		Short: "Publish a catalog from its committed source",
+		Long: `Publish an OPM catalog to its registry, at the coordinates the catalog itself
+declares.
+
+	The pipeline reads identity/identity.cue, validates it against core's
+	#IdentityPackage, derives repository/major/tag from the declared module path,
+	runs the publish gates, prints the resolved plan, and pushes. What is
+	published is exactly the committed tree — no copied build directory, no
+	generated version override.
+
+	Exit codes: 0 published (or dry-run GO), 2 refused, 3 registry unreachable.
+
+	Arguments:
+	  path    Path to the catalog directory (default: current directory)
+
+	Examples:
+	  # See the plan and every gate verdict without pushing
+	  opm catalog publish ./src --dry-run
+
+	  # Publish at the committed (release-owned) version
+	  opm catalog publish ./src
+
+	  # Assert the version being released
+	  opm catalog publish ./src --version 1.3.0`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			return cmdutil.RunPublish(c, cfg, publish.KindCatalog, args, &flags)
+		},
+	}
+
+	flags.AddTo(c)
+
+	return c
+}

--- a/internal/cmd/module/mod.go
+++ b/internal/cmd/module/mod.go
@@ -25,6 +25,7 @@ func NewModuleCmd(cfg *config.GlobalConfig) *cobra.Command {
 	c.AddCommand(NewModuleVetCmd(cfg))
 	c.AddCommand(NewModuleBuildCmd(cfg))
 	c.AddCommand(NewModuleApplyCmd(cfg))
+	c.AddCommand(NewModulePublishCmd(cfg))
 
 	return c
 }

--- a/internal/cmd/module/publish.go
+++ b/internal/cmd/module/publish.go
@@ -1,0 +1,51 @@
+package modulecmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-platform-model/cli/internal/cmdutil"
+	"github.com/open-platform-model/cli/internal/config"
+	"github.com/open-platform-model/cli/internal/publish"
+)
+
+// NewModulePublishCmd creates the module publish command.
+func NewModulePublishCmd(cfg *config.GlobalConfig) *cobra.Command {
+	var flags cmdutil.PublishFlags
+
+	c := &cobra.Command{
+		Use:   "publish [path]",
+		Short: "Publish a module from its committed source",
+		Long: `Publish an OPM module to its registry, at the coordinates the module itself
+declares.
+
+	The pipeline reads identity/identity.cue, validates it against core's
+	#IdentityPackage, derives repository/major/tag from the declared module path,
+	runs the publish gates, prints the resolved plan, and pushes. What is
+	published is exactly the committed tree.
+
+	Exit codes: 0 published (or dry-run GO), 2 refused, 3 registry unreachable.
+
+	Arguments:
+	  path    Path to the module directory (default: current directory)
+
+	Examples:
+	  # Publish the module in the current directory
+	  opm module publish
+
+	  # See the plan and every gate verdict without pushing
+	  opm module publish ./my-module --dry-run
+
+	  # Fill an open identity Version (writes identity/identity.cue), then publish
+	  opm module publish --version 1.3.0`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			return cmdutil.RunPublish(c, cfg, publish.KindModule, args, &flags)
+		},
+	}
+
+	flags.AddTo(c)
+	c.Flags().BoolVar(&flags.SkipOverrideCheck, "skip-override-check", false,
+		"Publish despite cue.mod/local-module.cue; replacements are ignored either way")
+
+	return c
+}

--- a/internal/cmd/module/publish_test.go
+++ b/internal/cmd/module/publish_test.go
@@ -1,0 +1,30 @@
+package modulecmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-platform-model/cli/internal/config"
+)
+
+func TestNewModulePublishCmd(t *testing.T) {
+	cmd := NewModulePublishCmd(&config.GlobalConfig{})
+
+	assert.Equal(t, "publish [path]", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+
+	require.NotNil(t, cmd.Flags().Lookup("version"))
+	require.NotNil(t, cmd.Flags().Lookup("dry-run"))
+	// D6's waiver is module-only, and its name says what it does: the gate is
+	// skipped, resolution never changes.
+	require.NotNil(t, cmd.Flags().Lookup("skip-override-check"))
+}
+
+func TestNewModulePublishCmd_NoLocalVerboseFlag(t *testing.T) {
+	cmd := NewModulePublishCmd(&config.GlobalConfig{})
+	assert.Nil(t, cmd.Flags().Lookup("verbose"),
+		"--verbose should not be a local flag (should use root persistent flag)")
+}

--- a/internal/cmd/module/vet.go
+++ b/internal/cmd/module/vet.go
@@ -8,12 +8,15 @@ import (
 	opmexit "github.com/open-platform-model/cli/internal/exit"
 
 	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/cuecontext"
 	"github.com/spf13/cobra"
+
+	"github.com/open-platform-model/library/opm/kernel"
+	"github.com/open-platform-model/library/opm/schema"
 
 	"github.com/open-platform-model/cli/internal/cmdutil"
 	"github.com/open-platform-model/cli/internal/config"
 	"github.com/open-platform-model/cli/internal/output"
+	"github.com/open-platform-model/cli/internal/publish"
 	"github.com/open-platform-model/cli/pkg/loader"
 	"github.com/open-platform-model/cli/pkg/validate"
 )
@@ -27,8 +30,11 @@ func NewModuleVetCmd(cfg *config.GlobalConfig) *cobra.Command {
 		Short: "Validate module without generating manifests",
 		Long: `Validate an OPM module's config inputs without generating manifests.
 
-	This command validates the module's #config contract using either the module's
-	debugValues (default) or explicit values files passed with -f/--values.
+	This command first verifies the module's identity and coordinates — the
+	identity package conforms to core's #IdentityPackage, metadata derives from
+	it, and cue.mod agrees with the declared module path — then validates the
+	module's #config contract using either the module's debugValues (default) or
+	explicit values files passed with -f/--values.
 	It does not render resources, resolve providers, or validate instance files.
 
 	Arguments:
@@ -45,7 +51,7 @@ func NewModuleVetCmd(cfg *config.GlobalConfig) *cobra.Command {
 	  opm module vet ./my-module -f base.cue -f prod.cue`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			return runVet(args, &rf)
+			return runVet(cfg, args, &rf)
 		},
 	}
 
@@ -54,18 +60,17 @@ func NewModuleVetCmd(cfg *config.GlobalConfig) *cobra.Command {
 	return c
 }
 
-func runVet(args []string, rf *cmdutil.RenderFlags) error {
+func runVet(cfg *config.GlobalConfig, args []string, rf *cmdutil.RenderFlags) error {
 	modulePath := cmdutil.ResolveModulePath(args)
-	return runVetModuleOnly(modulePath, rf)
+	return runVetModuleOnly(cfg, modulePath, rf)
 }
 
 // runVetModuleOnly validates a module directory without an instance.cue.
-// It loads the module CUE package, validates the schema, and checks that the
-// values (from -f flag or debugValues field) satisfy #config.
+// It loads the module CUE package with the resolved registry, runs the
+// identity/coordinate checks (D16/D18/D21), validates the schema, and checks
+// that the values (from -f flag or debugValues field) satisfy #config.
 // No instance wrapper, engine render, or cluster connection is required.
-func runVetModuleOnly(modulePath string, rf *cmdutil.RenderFlags) error {
-	cueCtx := cuecontext.New()
-
+func runVetModuleOnly(cfg *config.GlobalConfig, modulePath string, rf *cmdutil.RenderFlags) error {
 	if err := cmdutil.ValidateModuleInputPath(modulePath); err != nil {
 		return &opmexit.ExitError{
 			Code: opmexit.ExitGeneralError,
@@ -73,12 +78,32 @@ func runVetModuleOnly(modulePath string, rf *cmdutil.RenderFlags) error {
 		}
 	}
 
-	// Load and structurally validate the module CUE package.
-	modVal, err := loader.LoadModulePackage(cueCtx, modulePath)
+	cueCtx, identitySchema, err := identitySchemaForVet(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Identity and coordinate checks run between module load and the values
+	// stanza, so a module with no debugValues still reports coordinate drift.
+	plan, modVal, err := publish.VetChecks(publish.Options{
+		Dir:            modulePath,
+		Kind:           publish.KindModule,
+		Context:        cueCtx,
+		IdentitySchema: identitySchema,
+		Registry:       cfg.Registry,
+	})
 	if err != nil {
 		return &opmexit.ExitError{
 			Code: opmexit.ExitGeneralError,
-			Err:  fmt.Errorf("loading module: %w", err),
+			Err:  err,
+		}
+	}
+	if len(plan.Refusals) > 0 {
+		cmdutil.PrintRefusals(plan.Refusals)
+		return &opmexit.ExitError{
+			Code:    opmexit.ExitValidationError,
+			Err:     fmt.Errorf("module identity checks failed"),
+			Printed: true,
 		}
 	}
 
@@ -91,34 +116,16 @@ func runVetModuleOnly(modulePath string, rf *cmdutil.RenderFlags) error {
 	}
 	moduleLog := output.InstanceLogger(modName)
 
-	// Resolve the values to validate against #config.
-	valuesVals := make([]cue.Value, 0, len(rf.Values))
-	var valuesDetail string
+	moduleLog.Info(output.FormatVetCheck("Identity conforms to #IdentityPackage", "identity/identity.cue"))
+	moduleLog.Info(output.FormatVetCheck("Coordinates agree", plan.DeclaredPath))
+	if ver := versionState(plan); ver != "" {
+		moduleLog.Info(output.FormatVetCheck("Version matches path major", ver))
+	}
 
-	if len(rf.Values) > 0 {
-		basenames := make([]string, 0, len(rf.Values))
-		for _, valuesFile := range rf.Values {
-			valuesVal, loadErr := loader.LoadValuesFile(cueCtx, valuesFile)
-			if loadErr != nil {
-				return &opmexit.ExitError{
-					Code: opmexit.ExitGeneralError,
-					Err:  fmt.Errorf("loading values file %q: %w", valuesFile, loadErr),
-				}
-			}
-			valuesVals = append(valuesVals, valuesVal)
-			basenames = append(basenames, filepath.Base(valuesFile))
-		}
-		valuesDetail = strings.Join(basenames, ", ")
-	} else {
-		debugVal := modVal.LookupPath(cue.ParsePath("debugValues"))
-		if !debugVal.Exists() {
-			return &opmexit.ExitError{
-				Code: opmexit.ExitValidationError,
-				Err:  fmt.Errorf("module does not define debugValues - add debugValues or provide values with -f"),
-			}
-		}
-		valuesVals = append(valuesVals, debugVal)
-		valuesDetail = "debugValues"
+	// Resolve the values to validate against #config.
+	valuesVals, valuesDetail, err := resolveVetValues(cueCtx, modVal, rf)
+	if err != nil {
+		return err
 	}
 
 	for _, valuesVal := range valuesVals {
@@ -148,4 +155,74 @@ func runVetModuleOnly(modulePath string, rf *cmdutil.RenderFlags) error {
 	moduleLog.Info(output.FormatCheckmark("Module config valid"))
 
 	return nil
+}
+
+// identitySchemaForVet builds the per-invocation kernel — the CUE context
+// every load shares, and the schema cache the resolved registry threads into
+// (vet's loads no longer read only the ambient process environment) — and
+// resolves core's #IdentityPackage from it.
+func identitySchemaForVet(cfg *config.GlobalConfig) (*cue.Context, cue.Value, error) {
+	k := kernel.New(
+		kernel.WithRegistry(cfg.Registry),
+		kernel.WithSchemaLoader(schema.OCILoader{Registry: cfg.Registry}),
+	)
+	cueCtx := k.CueContext()
+	schemaVal, err := k.SchemaCache().Get(cueCtx)
+	if err != nil {
+		// A registry round-trip, same failure class as publish's lookup and
+		// push: connectivity (exit 3), not a verdict on the module.
+		return nil, cue.Value{}, &opmexit.ExitError{
+			Code: opmexit.ExitConnectivityError,
+			Err:  fmt.Errorf("loading core schema: %w", err),
+		}
+	}
+	identitySchema := schemaVal.LookupPath(cue.MakePath(cue.Def("IdentityPackage")))
+	if !identitySchema.Exists() {
+		return nil, cue.Value{}, &opmexit.ExitError{
+			Code: opmexit.ExitGeneralError,
+			Err:  fmt.Errorf("resolved core schema (%s) does not define #IdentityPackage; vet requires a core v2 schema", k.SchemaCache().ResolvedVersion()),
+		}
+	}
+	return cueCtx, identitySchema, nil
+}
+
+// resolveVetValues resolves the values to validate against #config: explicit
+// -f files, or the module's debugValues.
+func resolveVetValues(cueCtx *cue.Context, modVal cue.Value, rf *cmdutil.RenderFlags) ([]cue.Value, string, error) {
+	if len(rf.Values) > 0 {
+		valuesVals := make([]cue.Value, 0, len(rf.Values))
+		basenames := make([]string, 0, len(rf.Values))
+		for _, valuesFile := range rf.Values {
+			valuesVal, loadErr := loader.LoadValuesFile(cueCtx, valuesFile)
+			if loadErr != nil {
+				return nil, "", &opmexit.ExitError{
+					Code: opmexit.ExitGeneralError,
+					Err:  fmt.Errorf("loading values file %q: %w", valuesFile, loadErr),
+				}
+			}
+			valuesVals = append(valuesVals, valuesVal)
+			basenames = append(basenames, filepath.Base(valuesFile))
+		}
+		return valuesVals, strings.Join(basenames, ", "), nil
+	}
+
+	debugVal := modVal.LookupPath(cue.ParsePath("debugValues"))
+	if !debugVal.Exists() {
+		return nil, "", &opmexit.ExitError{
+			Code: opmexit.ExitValidationError,
+			Err:  fmt.Errorf("module does not define debugValues - add debugValues or provide values with -f"),
+		}
+	}
+	return []cue.Value{debugVal}, "debugValues", nil
+}
+
+// versionState returns the concrete identity Version for the vet-check line,
+// or "" when the field is open (a valid authoring state vet does not police).
+func versionState(plan *publish.Plan) string {
+	for _, f := range plan.Identity {
+		if f.Name == "Version" && f.State == publish.StateConcrete {
+			return f.Value
+		}
+	}
+	return ""
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cmdcatalog "github.com/open-platform-model/cli/internal/cmd/catalog"
 	cmdconfig "github.com/open-platform-model/cli/internal/cmd/config"
 	cmdinstance "github.com/open-platform-model/cli/internal/cmd/instance" // Was: cmdrelease "…/internal/cmd/release" (enhancement 0002 D6)
 	cmdmodule "github.com/open-platform-model/cli/internal/cmd/module"
@@ -51,6 +52,7 @@ func NewRootCmd() *cobra.Command {
 	// Add subcommands — sub-packages receive *config.GlobalConfig for dependency injection.
 	rootCmd.AddCommand(NewVersionCmd(&cfg))
 	rootCmd.AddCommand(cmdmodule.NewModuleCmd(&cfg))
+	rootCmd.AddCommand(cmdcatalog.NewCatalogCmd(&cfg))
 	rootCmd.AddCommand(cmdconfig.NewConfigCmd(&cfg))
 	rootCmd.AddCommand(cmdinstance.NewInstanceCmd(&cfg))
 	rootCmd.AddCommand(cmdoperator.NewOperatorCmd(&cfg))

--- a/internal/cmdutil/publish.go
+++ b/internal/cmdutil/publish.go
@@ -1,0 +1,148 @@
+package cmdutil
+
+import (
+	"errors"
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"github.com/spf13/cobra"
+
+	"github.com/open-platform-model/library/opm/kernel"
+	"github.com/open-platform-model/library/opm/schema"
+
+	"github.com/open-platform-model/cli/internal/config"
+	opmexit "github.com/open-platform-model/cli/internal/exit"
+	"github.com/open-platform-model/cli/internal/output"
+	"github.com/open-platform-model/cli/internal/publish"
+	oerrors "github.com/open-platform-model/cli/pkg/errors"
+)
+
+// PublishFlags holds the flags shared by `opm module publish` and
+// `opm catalog publish`.
+type PublishFlags struct {
+	// Version fills an open identity Version or asserts a concrete one
+	// (never overwrites — refusal 5).
+	Version string
+	// DryRun stops after the plan; every gate still runs, including the
+	// already-published lookup.
+	DryRun bool
+	// SkipOverrideCheck waives the local-override gate. Module publish only;
+	// catalog publish never registers it.
+	SkipOverrideCheck bool
+}
+
+// AddTo registers the shared publish flags on the given command.
+func (f *PublishFlags) AddTo(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.Version, "version", "",
+		"Fill an open identity Version, or assert the declared one")
+	cmd.Flags().BoolVar(&f.DryRun, "dry-run", false,
+		"Print the resolved plan and stop; all gates run, nothing is pushed")
+}
+
+// RunPublish is the shared body of both publish commands: resolve core's
+// #IdentityPackage from the kernel schema cache, compute the plan, print it,
+// print any refusals through the validation funnel, and push on GO outside
+// --dry-run. Exit codes: refusal 2, registry unreachable 3, unexpected 1.
+func RunPublish(cmd *cobra.Command, cfg *config.GlobalConfig, kind publish.Kind, args []string, flags *PublishFlags) error {
+	dir := ResolveModulePath(args)
+
+	k := kernel.New(
+		kernel.WithRegistry(cfg.Registry),
+		kernel.WithSchemaLoader(schema.OCILoader{Registry: cfg.Registry}),
+	)
+	schemaVal, err := k.SchemaCache().Get(k.CueContext())
+	if err != nil {
+		// The schema fetch is a registry round-trip like the lookup and the
+		// push: failing to reach it is a connectivity failure, not a verdict
+		// on the artifact.
+		return publishError(&publish.ConnectivityError{Op: "loading core schema", Err: err})
+	}
+	identitySchema := schemaVal.LookupPath(cue.MakePath(cue.Def("IdentityPackage")))
+	if !identitySchema.Exists() {
+		return &opmexit.ExitError{
+			Code: opmexit.ExitGeneralError,
+			Err:  fmt.Errorf("resolved core schema (%s) does not define #IdentityPackage; publish requires a core v2 schema", k.SchemaCache().ResolvedVersion()),
+		}
+	}
+
+	opts := publish.Options{
+		Dir:               dir,
+		Kind:              kind,
+		Context:           k.CueContext(),
+		IdentitySchema:    identitySchema,
+		Registry:          cfg.Registry,
+		VersionFlag:       flags.Version,
+		SkipOverrideCheck: flags.SkipOverrideCheck,
+	}
+
+	plan, runErr := publish.Run(cmd.Context(), opts)
+
+	// The plan prints on every invocation before any push — it is the dry
+	// run's whole output and the real run's preamble. That holds even when
+	// the registry was unreachable (runErr non-nil with a plan): every
+	// locally-derived refusal is already on the plan, and hiding it behind
+	// the connectivity error would bury the problems the author can fix
+	// right now.
+	if plan != nil {
+		fmt.Fprint(cmd.OutOrStdout(), plan.Render())
+		if !plan.Go() {
+			PrintRefusals(plan.Refusals)
+		}
+	}
+	if runErr != nil {
+		return publishError(runErr)
+	}
+
+	if !plan.Go() {
+		n := len(plan.Refusals)
+		noun := "refusal"
+		if n != 1 {
+			noun = "refusals"
+		}
+		return &opmexit.ExitError{
+			Code:    opmexit.ExitValidationError,
+			Err:     fmt.Errorf("publish refused: %d %s", n, noun),
+			Printed: true,
+		}
+	}
+
+	if flags.DryRun {
+		return nil
+	}
+
+	if err := publish.Push(cmd.Context(), opts, plan); err != nil {
+		return publishError(err)
+	}
+	output.Info(output.FormatCheckmark(fmt.Sprintf("Published %s:%s", plan.RegistryRepo, plan.Tag)))
+	return nil
+}
+
+// PrintRefusals routes each refusal through the standard validation-error
+// funnel: CUE-carrying refusals (load failures, identity non-conformance)
+// through the grouped path that preserves file:line, drafted messages as
+// ValidationError with aligned-column details. Shared by publish and the
+// vet checks.
+func PrintRefusals(refusals []publish.Refusal) {
+	for _, r := range refusals {
+		if r.Err != nil {
+			PrintValidationError(r.Headline, r.Err)
+			continue
+		}
+		PrintValidationError("refused", &oerrors.ValidationError{
+			Message: r.Headline,
+			Details: r.Details(),
+		})
+	}
+}
+
+// publishError maps pipeline errors to exit codes: registry unreachability
+// is a connectivity failure (3) — the artifact was never judged — and
+// anything else is unexpected (1).
+func publishError(err error) error {
+	code := opmexit.ExitGeneralError
+	var connErr *publish.ConnectivityError
+	if errors.As(err, &connErr) {
+		code = opmexit.ExitConnectivityError
+	}
+	return &opmexit.ExitError{Code: code, Err: err}
+}

--- a/internal/cmdutil/publish_test.go
+++ b/internal/cmdutil/publish_test.go
@@ -1,0 +1,48 @@
+package cmdutil
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	opmexit "github.com/open-platform-model/cli/internal/exit"
+	"github.com/open-platform-model/cli/internal/publish"
+)
+
+// TestPublishError_ExitCodes pins the pipeline-error → exit-code mapping:
+// registry unreachability is 3, anything else unexpected is 1.
+func TestPublishError_ExitCodes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "connectivity maps to ExitConnectivityError",
+			err:  &publish.ConnectivityError{Op: "listing published versions", Err: errors.New("dial tcp: refused")},
+			want: opmexit.ExitConnectivityError,
+		},
+		{
+			name: "wrapped connectivity still maps to ExitConnectivityError",
+			err:  fmt.Errorf("publishing: %w", &publish.ConnectivityError{Op: "push", Err: errors.New("timeout")}),
+			want: opmexit.ExitConnectivityError,
+		},
+		{
+			name: "anything else maps to ExitGeneralError",
+			err:  errors.New("zipping failed"),
+			want: opmexit.ExitGeneralError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := publishError(tt.err)
+			var exitErr *opmexit.ExitError
+			require.ErrorAs(t, err, &exitErr)
+			assert.Equal(t, tt.want, exitErr.Code)
+		})
+	}
+}

--- a/internal/cueedit/cueedit.go
+++ b/internal/cueedit/cueedit.go
@@ -1,0 +1,210 @@
+// Package cueedit performs surgical, position-based rewrites of OPM identity
+// files. It implements enhancement 0011 D8's Version write: locate the field
+// by its schema-fixed path in identity/identity.cue, splice the new value into
+// the original bytes, and leave every other byte — comments, alignment, field
+// order — exactly as committed. `opm ... publish --version` fills through this
+// writer; `version set` (cli-authoring-commands) reuses it.
+package cueedit
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/cue/token"
+)
+
+// ErrIdentityShape reports that identity/identity.cue does not match
+// #IdentityPackage's shape at the point the writer needs it to: the file is
+// absent, does not parse, or declares no Version field at the schema-fixed
+// path. Callers branch with errors.Is; the wrapped message names the file and
+// the specific mismatch.
+var ErrIdentityShape = errors.New("identity file does not match #IdentityPackage's shape")
+
+// versionRE mirrors core.#VersionType (bare SemVer 2.0, no "v" prefix).
+var versionRE = regexp.MustCompile(`^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$`)
+
+// SetIdentityVersion rewrites the Version field of dir/identity/identity.cue
+// to the given bare SemVer, preserving all surrounding bytes:
+//
+//   - a string literal value ("1.2.0", or one inside an "&" chain) is replaced;
+//   - a defaulted disjunction (#VersionType | *"1.2.0") has its default
+//     replaced — the field stays a default, so release automation that owns the
+//     committed value keeps owning it;
+//   - an open field (no string literal anywhere in the value) gains a
+//     unification with the version: `#VersionType` becomes
+//     `#VersionType & "1.2.0"`.
+//
+// An absent file, an unparseable file, or a missing Version field is a shape
+// refusal (ErrIdentityShape) — a malformed artifact, not an unfinished one.
+func SetIdentityVersion(dir, version string) error {
+	if !versionRE.MatchString(version) {
+		return fmt.Errorf("version %q is not a bare SemVer (expected MAJOR.MINOR.PATCH, no \"v\" prefix)", version)
+	}
+
+	path := filepath.Join(dir, "identity", "identity.cue")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%w: %s does not exist", ErrIdentityShape, path)
+		}
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	f, err := parser.ParseFile(path, data, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("%w: %s does not parse: %w", ErrIdentityShape, path, err)
+	}
+
+	field := topLevelField(f, "Version")
+	if field == nil {
+		return fmt.Errorf("%w: %s declares no top-level Version field", ErrIdentityShape, path)
+	}
+
+	edited, err := spliceVersion(data, field.Value, version)
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", ErrIdentityShape, path, err)
+	}
+
+	// The splice is byte surgery; prove the result still parses before it
+	// replaces the committed file.
+	if _, err := parser.ParseFile(path, edited); err != nil {
+		return fmt.Errorf("internal error: rewritten %s does not parse: %w", path, err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	return writeFileAtomic(path, edited, info.Mode().Perm())
+}
+
+// writeFileAtomic replaces path's content via a same-directory temp file and
+// rename, so a crash mid-write can never leave the committed identity file
+// truncated — this rewrites a file the author did not touch themselves.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".identity-*.cue.tmp")
+	if err != nil {
+		return fmt.Errorf("staging rewrite of %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("staging rewrite of %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("staging rewrite of %s: %w", path, err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("staging rewrite of %s: %w", path, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// topLevelField returns the top-level field with the given identifier label,
+// or nil.
+func topLevelField(f *ast.File, name string) *ast.Field {
+	for _, decl := range f.Decls {
+		field, ok := decl.(*ast.Field)
+		if !ok {
+			continue
+		}
+		if ident, ok := field.Label.(*ast.Ident); ok && ident.Name == name {
+			return field
+		}
+	}
+	return nil
+}
+
+// spliceVersion returns data with the Version field's value expression edited
+// to carry version, per the SetIdentityVersion contract.
+func spliceVersion(data []byte, value ast.Expr, version string) ([]byte, error) {
+	quoted := strconv.Quote(version)
+
+	if lit := versionLiteral(value); lit != nil {
+		start, end, err := span(lit)
+		if err != nil {
+			return nil, err
+		}
+		return splice(data, start, end, quoted), nil
+	}
+
+	// Open field: unify the existing expression with the version. A top-level
+	// disjunction needs parentheses so the "&" binds the whole expression.
+	start, end, err := span(value)
+	if err != nil {
+		return nil, err
+	}
+	if bin, ok := value.(*ast.BinaryExpr); ok && bin.Op == token.OR {
+		return splice(data, start, end, "("+string(data[start:end])+") & "+quoted), nil
+	}
+	return splice(data, start, end, string(data[start:end])+" & "+quoted), nil
+}
+
+// versionLiteral finds the string literal that carries the field's version:
+// the value itself, an operand of an "&" chain, or the defaulted arm of a
+// disjunction (preferred over non-default arms). Returns nil when the value
+// holds no version-carrying literal — the open-field case.
+func versionLiteral(expr ast.Expr) *ast.BasicLit {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind == token.STRING {
+			return e
+		}
+	case *ast.ParenExpr:
+		return versionLiteral(e.X)
+	case *ast.UnaryExpr:
+		if e.Op == token.MUL {
+			return versionLiteral(e.X)
+		}
+	case *ast.BinaryExpr:
+		// Only "|" and "&" chains can hold the version literal; any other
+		// operator (comparison, arithmetic, pattern match) does not.
+		if e.Op == token.OR {
+			// Prefer the defaulted arm — that is the committed, release-owned
+			// declaration.
+			for _, side := range []ast.Expr{e.X, e.Y} {
+				if u, ok := side.(*ast.UnaryExpr); ok && u.Op == token.MUL {
+					if lit := versionLiteral(u.X); lit != nil {
+						return lit
+					}
+				}
+			}
+		}
+		if e.Op == token.OR || e.Op == token.AND {
+			if lit := versionLiteral(e.X); lit != nil {
+				return lit
+			}
+			return versionLiteral(e.Y)
+		}
+	}
+	return nil
+}
+
+// span returns the byte offsets [start, end) of an expression in its file.
+func span(expr ast.Expr) (start, end int, err error) {
+	startPos, endPos := expr.Pos(), expr.End()
+	if !startPos.HasAbsPos() || !endPos.HasAbsPos() {
+		return 0, 0, fmt.Errorf("expression carries no absolute position")
+	}
+	return startPos.Position().Offset, endPos.Position().Offset, nil
+}
+
+// splice returns data with [start, end) replaced by repl.
+func splice(data []byte, start, end int, repl string) []byte {
+	out := make([]byte, 0, len(data)-(end-start)+len(repl))
+	out = append(out, data[:start]...)
+	out = append(out, repl...)
+	out = append(out, data[end:]...)
+	return out
+}

--- a/internal/cueedit/cueedit_test.go
+++ b/internal/cueedit/cueedit_test.go
@@ -1,0 +1,226 @@
+package cueedit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeIdentity creates dir/identity/identity.cue with the given content and
+// returns dir.
+func writeIdentity(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "identity"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "identity", "identity.cue"), []byte(content), 0o644))
+	return dir
+}
+
+func readIdentity(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "identity", "identity.cue"))
+	require.NoError(t, err)
+	return string(data)
+}
+
+// evalVersion evaluates the rewritten file (with defaults) and returns the
+// concrete Version string.
+func evalVersion(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "identity", "identity.cue"))
+	require.NoError(t, err)
+	v := cuecontext.New().CompileBytes(data)
+	require.NoError(t, v.Err())
+	s, err := v.LookupPath(cue.ParsePath("Version")).String()
+	require.NoError(t, err)
+	return s
+}
+
+func TestSetIdentityVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		version string
+		want    string // full expected file content after the rewrite
+	}{
+		{
+			name: "literal value replaced",
+			in: `package identity
+
+ModulePath: "opmodel.dev/modules/web_app@v1"
+Version:    "1.0.0"
+`,
+			version: "1.2.0",
+			want: `package identity
+
+ModulePath: "opmodel.dev/modules/web_app@v1"
+Version:    "1.2.0"
+`,
+		},
+		{
+			name: "defaulted value rewrites the default",
+			in: `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+"
+
+ModulePath: "opmodel.dev/catalogs/opm@v2"
+Version:    #VersionType | *"2.0.0-alpha.3" // x-release-please-version
+`,
+			version: "2.0.0-alpha.4",
+			want: `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+"
+
+ModulePath: "opmodel.dev/catalogs/opm@v2"
+Version:    #VersionType | *"2.0.0-alpha.4" // x-release-please-version
+`,
+		},
+		{
+			name: "open field gains a unification",
+			in: `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+"
+
+ModulePath: "opmodel.dev/modules/web_app@v1"
+Version:    #VersionType
+`,
+			version: "1.3.0",
+			want: `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+"
+
+ModulePath: "opmodel.dev/modules/web_app@v1"
+Version:    #VersionType & "1.3.0"
+`,
+		},
+		{
+			name: "open disjunction parenthesized before unifying",
+			in: `package identity
+
+Version: string | =~"^\\d"
+`,
+			version: "1.0.0",
+			want: `package identity
+
+Version: (string | =~"^\\d") & "1.0.0"
+`,
+		},
+		{
+			name: "literal inside an and-chain replaced",
+			in: `package identity
+
+#VersionType: string
+
+Version: #VersionType & "0.9.0"
+`,
+			version: "0.9.1",
+			want: `package identity
+
+#VersionType: string
+
+Version: #VersionType & "0.9.1"
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := writeIdentity(t, tt.in)
+			require.NoError(t, SetIdentityVersion(dir, tt.version))
+			assert.Equal(t, tt.want, readIdentity(t, dir))
+			assert.Equal(t, tt.version, evalVersion(t, dir))
+		})
+	}
+}
+
+func TestSetIdentityVersion_ShapeRefusals(t *testing.T) {
+	t.Run("absent file", func(t *testing.T) {
+		dir := t.TempDir()
+		err := SetIdentityVersion(dir, "1.0.0")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrIdentityShape)
+		assert.Contains(t, err.Error(), "identity.cue")
+	})
+
+	t.Run("missing Version field", func(t *testing.T) {
+		dir := writeIdentity(t, `package identity
+
+ModulePath: "opmodel.dev/modules/web_app@v1"
+`)
+		err := SetIdentityVersion(dir, "1.0.0")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrIdentityShape)
+		assert.Contains(t, err.Error(), "Version")
+	})
+
+	t.Run("renamed field is not searched for", func(t *testing.T) {
+		dir := writeIdentity(t, `package identity
+
+ModulePath:     "opmodel.dev/catalogs/opm@v2"
+CatalogVersion: "2.0.0"
+`)
+		err := SetIdentityVersion(dir, "1.0.0")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrIdentityShape)
+	})
+
+	t.Run("unparseable file", func(t *testing.T) {
+		dir := writeIdentity(t, `package identity
+
+Version: "1.0.0
+`)
+		err := SetIdentityVersion(dir, "1.0.0")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrIdentityShape)
+	})
+
+	t.Run("invalid version rejected before any read", func(t *testing.T) {
+		err := SetIdentityVersion(t.TempDir(), "v1.0.0")
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrIdentityShape)
+		assert.Contains(t, err.Error(), "SemVer")
+	})
+}
+
+// TestSetIdentityVersion_PreservesCommentsAndAlignment is the golden test for
+// the surgical property: every byte outside the version literal survives,
+// including doc comments, inline comments, alignment, and field order.
+func TestSetIdentityVersion_PreservesCommentsAndAlignment(t *testing.T) {
+	in := `// Package identity is the single source of this module's path and version
+// (core #IdentityPackage, enhancements 0010 D38 / 0011 D12).
+package identity
+
+// #VersionType mirrors core.#VersionType (SemVer 2.0), duplicated so this
+// package stays import-free.
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+// ModulePath is the module's complete CUE module path, major suffix included.
+ModulePath: "opmodel.dev/modules/web_app@v1"
+
+// Version is the module's bare SemVer; its major must agree with ModulePath's.
+Version: #VersionType | *"1.0.0"
+`
+	want := `// Package identity is the single source of this module's path and version
+// (core #IdentityPackage, enhancements 0010 D38 / 0011 D12).
+package identity
+
+// #VersionType mirrors core.#VersionType (SemVer 2.0), duplicated so this
+// package stays import-free.
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+// ModulePath is the module's complete CUE module path, major suffix included.
+ModulePath: "opmodel.dev/modules/web_app@v1"
+
+// Version is the module's bare SemVer; its major must agree with ModulePath's.
+Version: #VersionType | *"1.1.0"
+`
+
+	dir := writeIdentity(t, in)
+	require.NoError(t, SetIdentityVersion(dir, "1.1.0"))
+	assert.Equal(t, want, readIdentity(t, dir))
+}

--- a/internal/output/align.go
+++ b/internal/output/align.go
@@ -1,0 +1,54 @@
+package output
+
+import "strings"
+
+// AlignColumns renders rows of cells as left-aligned columns separated by
+// two spaces, each line prefixed by indent. Column widths are computed over
+// all rows; the last cell of each row is never padded, so ragged rows do not
+// leave trailing whitespace.
+//
+// This is the publish-refusal evidence form (enhancement 0011,
+// 06-operational.md): "disagreements print both values in aligned columns
+// with the file that declares each". Table is header-oriented and wrong for
+// two-value disagreements, hence this dedicated helper.
+func AlignColumns(indent string, rows [][]string) string {
+	widths := columnWidths(rows)
+
+	var b strings.Builder
+	for i, row := range rows {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(indent)
+		for j, cell := range row {
+			if j == len(row)-1 {
+				b.WriteString(cell)
+				break
+			}
+			b.WriteString(cell)
+			b.WriteString(strings.Repeat(" ", widths[j]-len(cell)+2))
+		}
+	}
+	return b.String()
+}
+
+// columnWidths returns the maximum cell width per column index. Cells that
+// are the last in their row are excluded — they are never padded, so they
+// must not widen the column for other rows either.
+func columnWidths(rows [][]string) []int {
+	var widths []int
+	for _, row := range rows {
+		for j, cell := range row {
+			if j == len(row)-1 {
+				continue
+			}
+			for len(widths) <= j {
+				widths = append(widths, 0)
+			}
+			if len(cell) > widths[j] {
+				widths[j] = len(cell)
+			}
+		}
+	}
+	return widths
+}

--- a/internal/output/align_test.go
+++ b/internal/output/align_test.go
@@ -1,0 +1,50 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlignColumns(t *testing.T) {
+	tests := []struct {
+		name string
+		rows [][]string
+		want string
+	}{
+		{
+			name: "two-value disagreement",
+			rows: [][]string{
+				{"declared", "opmodel.dev/catalogs/opm", "src/identity/identity.cue:22"},
+				{"cue.mod", "opmodel.dev/catalogs/opm-x", "src/cue.mod/module.cue:1"},
+			},
+			want: "  declared  opmodel.dev/catalogs/opm    src/identity/identity.cue:22\n" +
+				"  cue.mod   opmodel.dev/catalogs/opm-x  src/cue.mod/module.cue:1",
+		},
+		{
+			name: "ragged rows do not pad the last cell",
+			rows: [][]string{
+				{"--version", "2.4.1"},
+				{"declared", "2.4.0", "identity/identity.cue:18"},
+			},
+			want: "  --version  2.4.1\n" +
+				"  declared   2.4.0  identity/identity.cue:18",
+		},
+		{
+			name: "single row",
+			rows: [][]string{{"Version", "identity/identity.cue:9", "declared, never filled"}},
+			want: "  Version  identity/identity.cue:9  declared, never filled",
+		},
+		{
+			name: "empty",
+			rows: nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, AlignColumns("  ", tt.rows))
+		})
+	}
+}

--- a/internal/publish/fixtures_test.go
+++ b/internal/publish/fixtures_test.go
@@ -1,0 +1,159 @@
+package publish
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cuelabs.dev/go/oci/ociregistry/ocimem"
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/mod/modregistrytest"
+	"github.com/stretchr/testify/require"
+)
+
+// identitySchemaStub mirrors core.#IdentityPackage's authored surface for
+// hermetic unit tests: two required fields, closed, with the catalog's
+// derived declarations admitted. The real definition is exercised by the
+// registry-backed conformance test, which skips when the schema cannot be
+// resolved.
+const identitySchemaStub = `
+#IdentityPackage: {
+	ModulePath!:   string & =~"^[a-z0-9._-]+(/[a-z0-9._-]+)*@v[0-9]+$"
+	Version!:      string & =~"^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+	RegistryPath?: string
+	Major?:        string
+	kindPrefix?: [string]: string
+}
+`
+
+// stubSchema compiles the test #IdentityPackage definition.
+func stubSchema(t *testing.T, ctx *cue.Context) cue.Value {
+	t.Helper()
+	v := ctx.CompileString(identitySchemaStub)
+	require.NoError(t, v.Err())
+	def := v.LookupPath(cue.MakePath(cue.Def("IdentityPackage")))
+	require.True(t, def.Exists())
+	return def
+}
+
+// moduleFiles is a minimal conformant module tree with no external imports —
+// loads hermetically, passes every gate.
+func moduleFiles() map[string]string {
+	return map[string]string{
+		"cue.mod/module.cue": `module: "example.com/modules/demo@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+`,
+		"identity/identity.cue": `package identity
+
+ModulePath: "example.com/modules/demo@v1"
+Version:    "1.2.0"
+`,
+		"module.cue": `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+	version:    "1.2.0"
+}
+`,
+	}
+}
+
+// catalogFiles is the catalog twin: identity carries the derived
+// declarations, the root package is not named after metadata.name.
+func catalogFiles() map[string]string {
+	return map[string]string{
+		"cue.mod/module.cue": `module: "example.com/catalogs/demo@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+`,
+		"identity/identity.cue": `package identity
+
+ModulePath:   "example.com/catalogs/demo@v1"
+Version:      "1.2.0"
+RegistryPath: "example.com/catalogs/demo"
+`,
+		"catalog.cue": `package democat
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/catalogs/demo@v1"
+	version:    "1.2.0"
+}
+`,
+	}
+}
+
+// writeTree materializes files under a temp dir and returns it.
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+	return dir
+}
+
+// edit returns files with one entry replaced (or added).
+func edit(files map[string]string, name, content string) map[string]string {
+	out := make(map[string]string, len(files))
+	for k, v := range files {
+		out[k] = v
+	}
+	out[name] = content
+	return out
+}
+
+// emptyTestRegistry starts an in-process, immutable-tag OCI registry with
+// nothing in it and returns a CUE registry mapping routing every fixture
+// domain at it — the already-published lookup runs for real, off the network.
+func emptyTestRegistry(t *testing.T) string {
+	t.Helper()
+	reg, err := modregistrytest.NewServer(ocimem.NewWithConfig(&ocimem.Config{ImmutableTags: true}), nil)
+	require.NoError(t, err)
+	t.Cleanup(reg.Close)
+	return reg.Host() + "+insecure"
+}
+
+// runFixture runs the pipeline on files with the stub schema and an empty
+// in-process registry; tests that exercise the registry gates configure
+// their own.
+func runFixture(t *testing.T, kind Kind, files map[string]string, mutate ...func(*Options)) *Plan {
+	t.Helper()
+	dir := writeTree(t, files)
+	return runDir(t, kind, dir, mutate...)
+}
+
+func runDir(t *testing.T, kind Kind, dir string, mutate ...func(*Options)) *Plan {
+	t.Helper()
+	ctx := cuecontext.New()
+	opts := Options{
+		Dir:            dir,
+		Kind:           kind,
+		Context:        ctx,
+		IdentitySchema: stubSchema(t, ctx),
+		Registry:       emptyTestRegistry(t),
+	}
+	for _, m := range mutate {
+		m(&opts)
+	}
+	p, err := Run(context.Background(), opts)
+	require.NoError(t, err)
+	return p
+}
+
+// refusalHeadlines joins every refusal headline for containment asserts.
+func refusalHeadlines(p *Plan) string {
+	var b strings.Builder
+	for _, r := range p.Refusals {
+		b.WriteString(r.Headline)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/internal/publish/gates.go
+++ b/internal/publish/gates.go
@@ -1,0 +1,430 @@
+package publish
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"cuelang.org/go/cue"
+
+	"github.com/open-platform-model/cli/pkg/loader"
+)
+
+// Owned-domain shapes (D13/D14): the namespace rules bind only where OPM owns
+// the domain. Outside opmodel.dev and community.opmodel.dev publish asserts
+// nothing about the path — path ownership is domain ownership.
+var (
+	firstPartyShape = regexp.MustCompile(`^opmodel\.dev/(modules|catalogs|platforms)/[a-z0-9._-]+$`)
+	communityShape  = regexp.MustCompile(`^community\.opmodel\.dev/(m|catalogs|p)/[a-z0-9._-]+/[a-z0-9._-]+$`)
+)
+
+// Run computes the publish plan for one artifact: load, read identity, derive
+// coordinates, evaluate every evaluable gate, and accumulate refusals. It
+// never pushes and never writes; Push does both, after the caller has printed
+// the plan.
+//
+// A tree that does not load short-circuits with the load error — nothing
+// downstream is evaluable. Everything else accumulates, so one pass fixes
+// everything. The only registry round-trip is the already-published lookup;
+// an unreachable registry there returns a *ConnectivityError rather than a
+// refusal.
+func Run(ctx context.Context, opts Options) (*Plan, error) {
+	if opts.Context == nil {
+		return nil, fmt.Errorf("publish: Options.Context is required")
+	}
+	if !opts.IdentitySchema.Exists() {
+		return nil, fmt.Errorf("publish: Options.IdentitySchema is required")
+	}
+	absDir, err := statArtifactDir(opts.Dir)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Plan{Kind: opts.Kind, Dir: absDir}
+
+	// Gate: a tree without cue.mod is not a CUE module (D16, D20). Publish
+	// reads the module path from cue.mod and refuses to invent one, so
+	// nothing downstream is evaluable — short-circuit.
+	if !hasCueMod(absDir) {
+		p.refuse(noCueModRefusal(opts, absDir))
+		return p, nil
+	}
+
+	// Gate: the tree and its identity package must load. The load error is
+	// surfaced verbatim — reporting a failed load as "identity absent" would
+	// blame the wrong thing.
+	a, refusal := loadArtifact(opts)
+	if refusal != nil {
+		p.refuse(*refusal)
+		return p, nil
+	}
+	if err := a.readCueMod(opts.Context); err != nil {
+		p.refuse(Refusal{Headline: "cue.mod/module.cue cannot be read", Err: err})
+		return p, nil //nolint:nilerr // the read failure IS the refusal; the plan carries it
+	}
+	p.CueModPath, p.CueModPos = a.cueModPath, a.cueModPos
+
+	// Gate: identity conforms to #IdentityPackage (D21) — CUE's diagnostic,
+	// through the grouped funnel (refusal 10). Downstream gates still read
+	// the fields that do resolve.
+	if r := conformIdentity(a, opts.IdentitySchema); r != nil {
+		p.refuse(*r)
+	}
+
+	// Identity states (D4 tristate, defaults are concrete), coordinate
+	// derivation (read and split the declared path — never composed), and
+	// --version assert/fill (D3/D12).
+	p.Identity = identityStates(a)
+	p.DeclaredPath = requireConcreteModulePath(p)
+	if before, after, ok := strings.Cut(p.DeclaredPath, "@"); ok {
+		p.RegistryRepo, p.Major = before, after
+	}
+	resolveVersion(p, opts)
+
+	// The remaining gates, in dependency order; all evaluable ones run.
+	gateSourceSelf(p, a)
+	gateCueModAgreement(p, a)
+	gateDerivation(p, a)
+	gateTagMajor(p)
+	gateNamespace(p)
+	gateKindSegment(p)
+	gatePackageName(p, a)
+	gateOverride(p, opts)
+
+	// Gate: the tag must not already be published (D15) — the one registry
+	// round-trip before the push. The dry run runs it too: a dry run
+	// surfaces rejections, never defers them.
+	if err := gateAlreadyPublished(ctx, p, opts); err != nil {
+		return p, err
+	}
+
+	return p, nil
+}
+
+// noCueModRefusal is msg 3. When the identity package still loads on its own,
+// the action names the declared path; otherwise it shows the placeholder.
+func noCueModRefusal(opts Options, absDir string) Refusal {
+	modPath := "<module-path>"
+	if idVal, _, _, refusal := loadPackage(opts, absDir, "./identity"); refusal == nil {
+		if s, err := idVal.LookupPath(cue.ParsePath("ModulePath")).String(); err == nil {
+			modPath = s
+		}
+	}
+	return Refusal{
+		Headline:    fmt.Sprintf("no cue.mod/module.cue under %s — this is not a CUE module", absDir),
+		Consequence: "Publish reads the module path from cue.mod and refuses to invent one.",
+		//nolint:misspell // "Initialise" is the drafted message's spelling (0011 06-operational.md, msg 3) — the messages are normative
+		Action: fmt.Sprintf("Initialise it:  opm mod init %s", modPath),
+	}
+}
+
+// gateSourceSelf requires cue.mod's source: {kind: "self"} (push-mechanism
+// preflight): `self` selects the whole-directory zip, and CUE's publish
+// machinery refuses without it — better a gate in the house shape than a
+// late CUE error.
+func gateSourceSelf(p *Plan, a *artifact) {
+	if a.sourceKind == "self" {
+		return
+	}
+	evidence := [][]string{{"source", "absent", "cue.mod/module.cue"}}
+	if a.sourceKind != "" {
+		evidence = [][]string{{"source", fmt.Sprintf("{kind: %q}", a.sourceKind), "cue.mod/module.cue"}}
+	}
+	p.refuse(Refusal{
+		Headline:    "cue.mod/module.cue declares no `source: {kind: \"self\"}`",
+		Evidence:    evidence,
+		Consequence: "CUE's module machinery reads `source:` to decide which bytes form the\nartifact; `self` ships the committed directory as-is, with no VCS machinery.",
+		Action:      "Declare it:  cue mod edit --source self",
+	})
+}
+
+// gateCueModAgreement is msg 2: the artifact's declared path and cue.mod's
+// module: line must agree. Publishing under either value leaves the other
+// wrong, so publish will not choose.
+func gateCueModAgreement(p *Plan, a *artifact) {
+	if p.DeclaredPath == "" || a.cueModPath == p.DeclaredPath {
+		return
+	}
+	mp := p.identityField("ModulePath")
+	p.refuse(Refusal{
+		Headline: fmt.Sprintf("%s disagrees with itself about where it lives", p.DeclaredPath),
+		Evidence: [][]string{
+			{"declared", p.DeclaredPath, mp.Pos},
+			{"cue.mod", a.cueModPath, a.cueModPos},
+		},
+		Consequence: "cue.mod's `module:` line is what CUE resolves imports against — including\nthis module's own identity import. Publishing under either value leaves the\nother wrong.",
+		Action:      "Fix whichever is wrong; publish will not choose for you.",
+	})
+}
+
+// gateDerivation is msg 7 (D12): metadata.modulePath and metadata.version
+// must derive from the identity package. core cannot enforce the wiring — a
+// developer who replaces `id.Version` with a literal leaves nothing to
+// conflict — so publish compares the evaluated values. The identity side uses
+// the effective value, so a literal that would disagree after a --version
+// fill is caught now.
+func gateDerivation(p *Plan, a *artifact) {
+	type pair struct {
+		metaPath   string
+		identity   string // identity field name
+		derivation string
+	}
+	pairs := []pair{
+		{"metadata.modulePath", "ModulePath", "modulePath: id.ModulePath"},
+		{"metadata.version", "Version", "version: id.Version"},
+	}
+	for _, pr := range pairs {
+		idField := p.identityField(pr.identity)
+		if idField == nil || idField.Value == "" {
+			continue // nothing concrete to compare against; refused elsewhere
+		}
+		metaVal := a.root.LookupPath(cue.ParsePath(pr.metaPath))
+		if !metaVal.Exists() {
+			continue // shape problems are the schema's finding, not this gate's
+		}
+		metaStr, err := metaVal.String()
+		if err != nil || metaStr == idField.Value {
+			continue
+		}
+		metaPos := fieldPos(a.dir, metaVal)
+		file := strings.SplitN(metaPos, ":", 2)[0]
+		p.refuse(Refusal{
+			Headline: fmt.Sprintf("%s states a %s its identity package does not", file, strings.TrimPrefix(pr.metaPath, "metadata.")),
+			Evidence: [][]string{
+				{pr.metaPath, metaStr, metaPos},
+				{"id." + pr.identity, idField.Value, idField.Pos},
+			},
+			Action: fmt.Sprintf("Derive it:  %s", pr.derivation),
+		})
+	}
+}
+
+// gateTagMajor is msg 6's evaluable half plus #TagRef's binding: the tag is
+// constructed from the effective version, so tag == version holds by
+// construction, and what remains checkable is that the tag's major names the
+// major the path declares (D18).
+func gateTagMajor(p *Plan) {
+	if p.Tag == "" || p.Major == "" {
+		return
+	}
+	tagMajor := "v" + strings.SplitN(strings.TrimPrefix(p.Tag, "v"), ".", 2)[0]
+	if tagMajor == p.Major {
+		return
+	}
+	mp := p.identityField("ModulePath")
+	p.refuse(Refusal{
+		Headline: "the tag would not name a version within the major this artifact's path declares",
+		Evidence: [][]string{
+			{"tag", p.Tag, p.TagSource},
+			{"path major", p.Major, mp.Pos},
+		},
+		Consequence: fmt.Sprintf("Published this way, the registry would serve %s tags from a repository\nwhose path promises %s — a pin on the path's major would never resolve it.", tagMajor, p.Major),
+		Action:      fmt.Sprintf("Publish a %s.N.N version, or move the path to its next major first.", p.Major),
+	})
+}
+
+// gateNamespace enforces the owned-domain path shapes (D13): exact inside
+// opmodel.dev and community.opmodel.dev, silent everywhere else — a vanity
+// domain or a self-hosted registry may use any valid CUE module path.
+// opmodel.dev/core is the fixed path outside the kind pattern;
+// testing.opmodel.dev is a separate domain and deliberately not caught.
+func gateNamespace(p *Plan) {
+	repo := p.RegistryRepo
+	if repo == "" || !ownedDomain(repo) || repo == "opmodel.dev/core" {
+		return
+	}
+	shape, allowed := firstPartyShape, "opmodel.dev/(modules|catalogs|platforms)/<name>"
+	if strings.HasPrefix(repo, "community.opmodel.dev/") {
+		shape, allowed = communityShape, "community.opmodel.dev/(m|catalogs|p)/<owner>/<name>"
+	}
+	if shape.MatchString(repo) {
+		return
+	}
+	mp := p.identityField("ModulePath")
+	p.refuse(Refusal{
+		Headline: fmt.Sprintf("%s does not fit the namespace this domain publishes", repo),
+		Evidence: [][]string{
+			{"declared", p.DeclaredPath, mp.Pos},
+			{"expected", allowed},
+		},
+		Consequence: "Inside the domains OPM owns the path shape is exact; fixtures belong under\ntesting.opmodel.dev, and third-party domains are unconstrained.",
+		Action:      "Declare a path matching the shape above, or publish under your own domain.",
+	})
+}
+
+// gateKindSegment: inside the owned domains the kind segment must agree with
+// what is being published — one implementation with two entry points means
+// nothing else stops `opm module publish` landing where consumers look for
+// catalogs. No platforms arm: nothing publishes a platform today (D14).
+func gateKindSegment(p *Plan) {
+	repo := p.RegistryRepo
+	if repo == "" || !ownedDomain(repo) || repo == "opmodel.dev/core" {
+		return
+	}
+	segments := strings.Split(repo, "/")
+	if len(segments) < 2 {
+		return
+	}
+	seg := segments[1]
+	agrees := false
+	switch p.Kind {
+	case KindModule:
+		agrees = seg == "modules" || seg == "m"
+	case KindCatalog:
+		agrees = seg == "catalogs"
+	}
+	if agrees {
+		return
+	}
+	mp := p.identityField("ModulePath")
+	p.refuse(Refusal{
+		Headline: fmt.Sprintf("a %s cannot publish under the %s/ segment", p.Kind, seg),
+		Evidence: [][]string{
+			{"kind", string(p.Kind)},
+			{"declared", p.DeclaredPath, mp.Pos},
+		},
+		Consequence: "The kind segment is where consumers look for this artifact kind; publishing\nacross it files the artifact where nothing will find it.",
+		Action:      fmt.Sprintf("Declare a path under the %s segment for this kind, or publish with the\nmatching command.", expectedSegment(p.Kind, repo)),
+	})
+}
+
+func ownedDomain(repo string) bool {
+	return strings.HasPrefix(repo, "opmodel.dev/") || strings.HasPrefix(repo, "community.opmodel.dev/")
+}
+
+func expectedSegment(kind Kind, repo string) string {
+	if kind == KindCatalog {
+		return "catalogs/"
+	}
+	if strings.HasPrefix(repo, "community.opmodel.dev/") {
+		return "m/"
+	}
+	return "modules/"
+}
+
+// gatePackageName is D1's module package-name rule: the module's root package
+// must bind to its metadata.name, because a consumer's bare import binds the
+// package name. The catalog entry point skips it — a catalog's importable
+// surface is its subpackages.
+func gatePackageName(p *Plan, a *artifact) {
+	if p.Kind != KindModule || a.rootPkgName == "" {
+		return
+	}
+	nameVal := a.root.LookupPath(cue.ParsePath("metadata.name"))
+	name, err := nameVal.String()
+	if err != nil || name == "" || a.rootPkgName == name {
+		return
+	}
+	importPath := p.DeclaredPath
+	if importPath == "" {
+		importPath = "<module-path>"
+	}
+	p.refuse(Refusal{
+		Headline: fmt.Sprintf("%s's package does not bind to its name", filepath.Base(p.Dir)),
+		Evidence: [][]string{
+			{"package", a.rootPkgName, a.rootPkgPos},
+			{"name", name, fieldPos(a.dir, nameVal) + " — via metadata.name"},
+		},
+		Consequence: fmt.Sprintf("A consumer's bare `import %q` binds the package\nname; when they differ every consumer must alias the import.", importPath),
+		Action:      fmt.Sprintf("Rename the package:  package %s", name),
+	})
+}
+
+// gateOverride is D6: local overrides are never honored — CUE strips the file
+// and the artifact always resolves as published. What is in question is
+// whether what was tested matches what is shipped. The condition is the
+// file's presence; --skip-override-check waives the gate for modules only and
+// changes nothing else. A catalog's divergence propagates into the key space
+// of everything built against it, so it has no waiver.
+func gateOverride(p *Plan, opts Options) {
+	moduleRoot := loader.ModuleRootFrom(p.Dir)
+	p.OverridePresent = loader.HasLocalModuleReplacement(moduleRoot)
+	if !p.OverridePresent {
+		return
+	}
+	p.Replacements = readReplacements(opts.Context, p.Dir)
+
+	evidence := make([][]string, 0, len(p.Replacements))
+	for _, r := range p.Replacements {
+		resolves := "(not pinned in cue.mod — the published artifact will not resolve it)"
+		if r.PublishedVersion != "" {
+			resolves = fmt.Sprintf("(would resolve to %s when published)", r.PublishedVersion)
+		}
+		evidence = append(evidence, []string{r.Path, "→ " + r.ReplaceWith, resolves})
+	}
+
+	if p.Kind == KindCatalog {
+		p.refuse(Refusal{
+			Headline:    "cue.mod/local-module.cue is present; a catalog cannot be published from a tree configured for local development",
+			Evidence:    evidence,
+			Consequence: "A catalog's dependency divergence propagates into the key space of every\nmodule built against it, so there is no override for this one.",
+			Action:      "Remove the file and re-vet before publishing.",
+		})
+		return
+	}
+
+	if opts.SkipOverrideCheck {
+		p.OverrideWaived = true
+		return
+	}
+	p.refuse(Refusal{
+		Headline:    "cue.mod/local-module.cue is present; this module was validated against local checkouts, not against what a consumer will resolve",
+		Evidence:    evidence,
+		Consequence: "The replacements are ignored either way — CUE strips the file and the\nartifact always resolves as published. What is in question is whether what\nyou tested matches what you are shipping.",
+		Action:      "Remove the file, or publish anyway with --skip-override-check if the\nsubstitution above is immaterial.",
+	})
+}
+
+// readReplacements lists local-module.cue's replaceWith entries beside the
+// version cue.mod/module.cue pins for the same dependency — the substitution
+// the author sees, rather than a rule citation.
+func readReplacements(ctx *cue.Context, dir string) []Replacement {
+	data, err := os.ReadFile(filepath.Join(dir, "cue.mod", "local-module.cue"))
+	if err != nil {
+		return nil
+	}
+	pins := map[string]string{}
+	if modData, err := os.ReadFile(filepath.Join(dir, "cue.mod", "module.cue")); err == nil {
+		modVal := ctx.CompileBytes(modData)
+		if deps := modVal.LookupPath(cue.ParsePath("deps")); deps.Exists() {
+			if iter, err := deps.Fields(); err == nil {
+				for iter.Next() {
+					if v, err := iter.Value().LookupPath(cue.ParsePath("v")).String(); err == nil {
+						pins[iter.Selector().Unquoted()] = v
+					}
+				}
+			}
+		}
+	}
+
+	var out []Replacement
+	v := ctx.CompileBytes(data)
+	deps := v.LookupPath(cue.ParsePath("deps"))
+	if !deps.Exists() {
+		return nil
+	}
+	iter, err := deps.Fields()
+	if err != nil {
+		return nil
+	}
+	for iter.Next() {
+		depPath := iter.Selector().Unquoted()
+		rw := iter.Value().LookupPath(cue.ParsePath("replaceWith"))
+		if !rw.Exists() {
+			continue
+		}
+		target, err := rw.String()
+		if err != nil {
+			target = "<replacement>"
+		}
+		out = append(out, Replacement{
+			Path:             depPath,
+			ReplaceWith:      target,
+			PublishedVersion: pins[depPath],
+		})
+	}
+	return out
+}

--- a/internal/publish/gates_test.go
+++ b/internal/publish/gates_test.go
@@ -1,0 +1,364 @@
+package publish
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withDeclaredPath rewrites a module fixture's three path statements to the
+// given declared path (major included), declaring a version whose major
+// matches the path's.
+func withDeclaredPath(files map[string]string, path string) map[string]string {
+	version := versionForPath(path)
+	out := edit(files, "cue.mod/module.cue", fmt.Sprintf(`module: %q
+language: version: "v0.17.0"
+source: kind: "self"
+`, path))
+	out = edit(out, "identity/identity.cue", fmt.Sprintf(`package identity
+
+ModulePath: %q
+Version:    %q
+`, path, version))
+	out = edit(out, "module.cue", fmt.Sprintf(`package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: %q
+	version:    %q
+}
+`, path, version))
+	return out
+}
+
+func TestGate_NoCueMod(t *testing.T) {
+	files := moduleFiles()
+	delete(files, "cue.mod/module.cue")
+	p := runFixture(t, KindModule, files)
+
+	require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+	r := p.Refusals[0]
+	assert.Contains(t, r.Headline, "no cue.mod/module.cue")
+	assert.Contains(t, r.Headline, "this is not a CUE module")
+	// The identity package still loads on its own, so the action names the
+	// declared path rather than a placeholder.
+	assert.Contains(t, r.Action, "opm mod init example.com/modules/demo@v1")
+}
+
+func TestGate_CueModAgreement(t *testing.T) {
+	files := edit(moduleFiles(), "cue.mod/module.cue", `module: "example.com/modules/other@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+`)
+	p := runFixture(t, KindModule, files)
+
+	require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+	r := p.Refusals[0]
+	assert.Contains(t, r.Headline, "disagrees with itself about where it lives")
+	details := r.Details()
+	assert.Contains(t, details, "example.com/modules/demo@v1")
+	assert.Contains(t, details, "example.com/modules/other@v1")
+	assert.Contains(t, details, "identity/identity.cue:")
+	assert.Contains(t, details, "cue.mod/module.cue:")
+	assert.Contains(t, r.Action, "publish will not choose for you")
+}
+
+func TestGate_SourceSelf(t *testing.T) {
+	t.Run("absent source refused", func(t *testing.T) {
+		files := edit(moduleFiles(), "cue.mod/module.cue", `module: "example.com/modules/demo@v1"
+language: version: "v0.17.0"
+`)
+		p := runFixture(t, KindModule, files)
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		assert.Contains(t, p.Refusals[0].Headline, `source: {kind: "self"}`)
+		assert.Contains(t, p.Refusals[0].Action, "cue mod edit --source self")
+	})
+
+	t.Run("other kind refused with the value named", func(t *testing.T) {
+		files := edit(moduleFiles(), "cue.mod/module.cue", `module: "example.com/modules/demo@v1"
+language: version: "v0.17.0"
+source: kind: "git"
+`)
+		p := runFixture(t, KindModule, files)
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		assert.Contains(t, p.Refusals[0].Details(), `{kind: "git"}`)
+	})
+}
+
+func TestGate_Derivation(t *testing.T) {
+	t.Run("metadata.version literal drift is msg 7", func(t *testing.T) {
+		files := edit(moduleFiles(), "module.cue", `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+	version:    "1.1.0"
+}
+`)
+		p := runFixture(t, KindModule, files)
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		r := p.Refusals[0]
+		assert.Contains(t, r.Headline, "states a version its identity package does not")
+		details := r.Details()
+		assert.Contains(t, details, "metadata.version")
+		assert.Contains(t, details, "1.1.0")
+		assert.Contains(t, details, "id.Version")
+		assert.Contains(t, details, "1.2.0")
+		assert.Contains(t, r.Action, "version: id.Version")
+	})
+
+	t.Run("metadata.modulePath drift caught too", func(t *testing.T) {
+		files := edit(moduleFiles(), "module.cue", `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo-x@v1"
+	version:    "1.2.0"
+}
+`)
+		p := runFixture(t, KindModule, files)
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		assert.Contains(t, p.Refusals[0].Action, "modulePath: id.ModulePath")
+	})
+
+	t.Run("filled version compared against the fill", func(t *testing.T) {
+		files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+"
+
+ModulePath: "example.com/modules/demo@v1"
+Version:    #VersionType
+`)
+		// metadata.version keeps a literal that will disagree once --version
+		// fills the open field: published bytes would be inconsistent, so it
+		// is caught now.
+		p := runFixture(t, KindModule, files, func(o *Options) { o.VersionFlag = "1.3.0" })
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		assert.Contains(t, p.Refusals[0].Headline, "states a version its identity package does not")
+	})
+}
+
+func TestGate_TagMajor(t *testing.T) {
+	files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+ModulePath: "example.com/modules/demo@v2"
+Version:    "1.2.0"
+`)
+	files = edit(files, "cue.mod/module.cue", `module: "example.com/modules/demo@v2"
+language: version: "v0.17.0"
+source: kind: "self"
+`)
+	files = edit(files, "module.cue", `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v2"
+	version:    "1.2.0"
+}
+`)
+	p := runFixture(t, KindModule, files)
+
+	require.NotEmpty(t, p.Refusals)
+	var tagRefusal *Refusal
+	for i := range p.Refusals {
+		if strings.Contains(p.Refusals[i].Headline, "within the major") {
+			tagRefusal = &p.Refusals[i]
+		}
+	}
+	require.NotNil(t, tagRefusal, refusalHeadlines(p))
+	details := tagRefusal.Details()
+	assert.Contains(t, details, "v1.2.0")
+	assert.Contains(t, details, "v2")
+}
+
+// TestGate_Namespace pins the four passing cases from 0011's
+// schemas/target.cue — the constraint D13 exists to keep from growing until
+// it refuses a third party's own domain — and the measured must-fail shapes.
+func TestGate_Namespace(t *testing.T) {
+	passing := []struct {
+		name string
+		kind Kind
+		path string
+	}{
+		{"vanity domain is unconstrained", KindCatalog, "example.com/k8up@v1"},
+		{"testing domain is a separate domain, not policed", KindModule, "testing.opmodel.dev/modules/web_app@v1"},
+		{"community module with owner segment", KindModule, "community.opmodel.dev/m/acme/media_server@v2"},
+		{"opmodel.dev/core is the fixed path outside the kind pattern", KindCatalog, "opmodel.dev/core@v1"},
+	}
+	for _, tt := range passing {
+		t.Run(tt.name, func(t *testing.T) {
+			files := withDeclaredPath(moduleFiles(), tt.path)
+			p := runFixture(t, tt.kind, files)
+			assert.Empty(t, p.Refusals, refusalHeadlines(p))
+		})
+	}
+
+	refused := []struct {
+		name string
+		kind Kind
+		path string
+		want string
+	}{
+		{"abandoned owner-scoped first-party shape", KindModule, "opmodel.dev/m/acme/postgres@v1", "does not fit the namespace"},
+		{"unreserved releases segment", KindModule, "opmodel.dev/releases/prod@v1", "does not fit the namespace"},
+		{"nested path under a valid kind segment", KindModule, "opmodel.dev/modules/test/hello_web@v1", "does not fit the namespace"},
+		{"module published to a catalogs path", KindModule, "opmodel.dev/catalogs/opm@v1", "cannot publish under the catalogs/ segment"},
+		{"catalog published to a modules path", KindCatalog, "opmodel.dev/modules/demo@v1", "cannot publish under the modules/ segment"},
+	}
+	for _, tt := range refused {
+		t.Run(tt.name, func(t *testing.T) {
+			files := withDeclaredPath(moduleFiles(), tt.path)
+			p := runFixture(t, tt.kind, files)
+			assert.Contains(t, refusalHeadlines(p), tt.want)
+		})
+	}
+}
+
+// versionForPath returns a version whose major matches the path's, so the
+// namespace pins are not polluted by tag-major refusals.
+func versionForPath(path string) string {
+	if strings.HasSuffix(path, "@v2") {
+		return "2.4.1"
+	}
+	return "1.2.0"
+}
+
+func TestGate_PackageName(t *testing.T) {
+	misnamed := edit(moduleFiles(), "module.cue", `package demo_db
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+	version:    "1.2.0"
+}
+`)
+
+	t.Run("module package must bind to metadata.name", func(t *testing.T) {
+		p := runFixture(t, KindModule, misnamed)
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		r := p.Refusals[0]
+		assert.Contains(t, r.Headline, "package does not bind to its name")
+		details := r.Details()
+		assert.Contains(t, details, "demo_db")
+		assert.Contains(t, details, "module.cue:1")
+		assert.Contains(t, details, "via metadata.name")
+		assert.Contains(t, r.Action, "package demo")
+	})
+
+	t.Run("catalog entry point skips the gate", func(t *testing.T) {
+		// catalogFiles' root package (democat) already differs from
+		// metadata.name (demo); the clean-catalog test passing is the same
+		// pin, restated here for the contrast.
+		p := runFixture(t, KindCatalog, catalogFiles())
+		assert.Empty(t, p.Refusals, refusalHeadlines(p))
+	})
+}
+
+// TestGate_Override covers all four presence/flag states for both kinds
+// (D6). The flag waives the gate for modules only, and changes nothing else.
+func TestGate_Override(t *testing.T) {
+	// The override entry names a dep that is pinned but never imported, so
+	// the tree still loads without resolving it.
+	withOverride := func(files map[string]string, modPath string) map[string]string {
+		out := edit(files, "cue.mod/module.cue", fmt.Sprintf(`module: %q
+language: version: "v0.17.0"
+source: kind: "self"
+deps: "example.com/dep@v1": v: "v1.4.0"
+`, modPath))
+		return edit(out, "cue.mod/local-module.cue", `deps: "example.com/dep@v1": replaceWith: "../dep"
+`)
+	}
+
+	t.Run("module with override refused, escape hatch offered by name", func(t *testing.T) {
+		p := runFixture(t, KindModule, withOverride(moduleFiles(), "example.com/modules/demo@v1"))
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		r := p.Refusals[0]
+		assert.Contains(t, r.Headline, "local-module.cue is present")
+		details := r.Details()
+		assert.Contains(t, details, "example.com/dep@v1")
+		assert.Contains(t, details, "../dep")
+		assert.Contains(t, details, "would resolve to v1.4.0 when published")
+		assert.Contains(t, r.Action, "--skip-override-check")
+		assert.True(t, p.OverridePresent)
+	})
+
+	t.Run("module with override and flag proceeds, gate waived only", func(t *testing.T) {
+		p := runFixture(t, KindModule, withOverride(moduleFiles(), "example.com/modules/demo@v1"),
+			func(o *Options) { o.SkipOverrideCheck = true })
+		assert.Empty(t, p.Refusals, refusalHeadlines(p))
+		assert.True(t, p.OverridePresent)
+		assert.True(t, p.OverrideWaived)
+		// The replacements are still reported — ignored, not honored.
+		require.Len(t, p.Replacements, 1)
+		assert.Equal(t, "v1.4.0", p.Replacements[0].PublishedVersion)
+	})
+
+	t.Run("catalog with override refused", func(t *testing.T) {
+		p := runFixture(t, KindCatalog, withOverride(catalogFiles(), "example.com/catalogs/demo@v1"))
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		assert.Contains(t, p.Refusals[0].Headline, "a catalog cannot be published")
+		assert.NotContains(t, p.Refusals[0].Action, "--skip-override-check")
+	})
+
+	t.Run("catalog with override and flag still refused", func(t *testing.T) {
+		p := runFixture(t, KindCatalog, withOverride(catalogFiles(), "example.com/catalogs/demo@v1"),
+			func(o *Options) { o.SkipOverrideCheck = true })
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		assert.False(t, p.OverrideWaived)
+	})
+
+	t.Run("clean trees pass for both kinds", func(t *testing.T) {
+		assert.Empty(t, runFixture(t, KindModule, moduleFiles()).Refusals)
+		assert.Empty(t, runFixture(t, KindCatalog, catalogFiles()).Refusals)
+	})
+}
+
+// TestRun_RefusalsAccumulate: every evaluable gate runs and one invocation
+// reports every defect — one pass fixes everything.
+func TestRun_RefusalsAccumulate(t *testing.T) {
+	files := edit(moduleFiles(), "cue.mod/module.cue", `module: "example.com/modules/other@v1"
+language: version: "v0.17.0"
+deps: "example.com/dep@v1": v: "v1.4.0"
+`)
+	files = edit(files, "cue.mod/local-module.cue", `deps: "example.com/dep@v1": replaceWith: "../dep"
+`)
+	p := runFixture(t, KindModule, files)
+
+	headlines := refusalHeadlines(p)
+	assert.Contains(t, headlines, "disagrees with itself")
+	assert.Contains(t, headlines, "source")
+	assert.Contains(t, headlines, "local-module.cue is present")
+	assert.Len(t, p.Refusals, 3, headlines)
+}
+
+func TestPlan_Render(t *testing.T) {
+	t.Run("GO plan shows every resolved coordinate", func(t *testing.T) {
+		p := runFixture(t, KindModule, moduleFiles())
+		out := p.Render()
+		assert.Contains(t, out, "kind            module")
+		assert.Contains(t, out, "declaredPath    example.com/modules/demo@v1")
+		assert.Contains(t, out, "cueModPath      example.com/modules/demo@v1")
+		assert.Contains(t, out, "registryRepo    example.com/modules/demo")
+		assert.Contains(t, out, "major           v1")
+		assert.Contains(t, out, "tag             v1.2.0")
+		assert.Contains(t, out, "tag from        the artifact's own Version")
+		assert.Contains(t, out, "ModulePath")
+		assert.Contains(t, out, "Version")
+		assert.Contains(t, out, "local override  false")
+		assert.Contains(t, out, "GO — pushing example.com/modules/demo:v1.2.0")
+	})
+
+	t.Run("refused plan carries the count, not the details", func(t *testing.T) {
+		files := edit(moduleFiles(), "cue.mod/module.cue", `module: "example.com/modules/other@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+`)
+		p := runFixture(t, KindModule, files)
+		out := p.Render()
+		assert.Contains(t, out, "REFUSED — 1 refusal")
+		assert.NotContains(t, out, "GO")
+	})
+}

--- a/internal/publish/identity.go
+++ b/internal/publish/identity.go
@@ -1,0 +1,156 @@
+package publish
+
+import (
+	"fmt"
+	"strings"
+
+	"cuelang.org/go/cue"
+	cueerrors "cuelang.org/go/cue/errors"
+)
+
+// identityFieldNames are the schema-fixed paths publish reads, per
+// core.#IdentityPackage. There is no marker to scan for — the name is where
+// the schema puts the field, and a field not at its path is absent (a
+// malformed artifact, not a cue to search wider).
+var identityFieldNames = []string{"ModulePath", "Version"}
+
+// conformIdentity unifies the identity package against core's
+// #IdentityPackage and returns refusal 10 on failure. CUE's own error is
+// surfaced — a procedural expected-versus-found check would be a second
+// statement of the contract, and the two drift.
+func conformIdentity(a *artifact, schema cue.Value) *Refusal {
+	unified := schema.Unify(a.identity)
+	err := unified.Validate(cue.Concrete(true))
+	if err == nil {
+		return nil
+	}
+
+	// Concrete validation is what makes CUE name a missing required field
+	// ("field is required but not present"). It also flags open fields as
+	// incomplete — but openness is D4's gate (refusal 1, fillable by
+	// --version), not a conformance failure, so incompleteness errors are
+	// dropped here. One cause, one refusal.
+	var kept cueerrors.Error
+	for _, e := range cueerrors.Errors(err) {
+		if strings.Contains(e.Error(), "incomplete value") {
+			continue
+		}
+		kept = cueerrors.Append(kept, e)
+	}
+	if kept == nil {
+		return nil
+	}
+	return &Refusal{
+		Headline: "the identity package does not conform to core's #IdentityPackage",
+		Err:      kept,
+	}
+}
+
+// identityStates classifies each schema-fixed identity field per D4's
+// tristate, evaluating with CUE defaults: a defaulted field is concrete with
+// the default as its value — that is the committed, release-automation-owned
+// declaration.
+func identityStates(a *artifact) []IdentityField {
+	out := make([]IdentityField, 0, len(identityFieldNames))
+	for _, name := range identityFieldNames {
+		f := IdentityField{Name: name, State: StateAbsent}
+		v := a.identity.LookupPath(cue.ParsePath(name))
+		if v.Exists() {
+			f.State = StateOpen
+			f.Pos = fieldPos(a.dir, v)
+			if s, err := v.String(); err == nil {
+				f.State, f.Value = StateConcrete, s
+				_, f.Defaulted = v.Default()
+			}
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// resolveVersion applies D3/D12's --version semantics to the Version field
+// and sets the plan's tag: fill an open field (recording the pending
+// working-tree write), assert a concrete one, never overwrite. One cause,
+// one refusal: an absent field is refusal 10's finding and produces nothing
+// here.
+func resolveVersion(p *Plan, opts Options) {
+	ver := p.identityField("Version")
+	if ver == nil || ver.State == StateAbsent {
+		return
+	}
+
+	flag := opts.VersionFlag
+	switch {
+	case ver.State == StateConcrete && flag != "" && flag != ver.Value:
+		p.refuse(Refusal{
+			Headline: "--version disagrees with the version this artifact declares",
+			Evidence: [][]string{
+				{"--version", flag},
+				{"declared", ver.Value, ver.Pos},
+			},
+			Consequence: "--version fills an open field or asserts a concrete one. It never\noverwrites a value someone decided.",
+			Action:      fmt.Sprintf("Change the flag, or:  opm %s version set %s", p.Kind, flag),
+		})
+	case ver.State == StateConcrete:
+		p.Tag = "v" + ver.Value
+		p.TagSource = "the artifact's own Version"
+		if ver.Defaulted {
+			p.TagSource += " (default)"
+		}
+	case flag != "":
+		// Open + flag: the fill writes the working tree (D12) — an in-memory
+		// overlay would publish bytes the tree does not hold. Push performs
+		// the write; the plan records it.
+		ver.Filled = true
+		ver.Value = flag
+		p.FillVersion = flag
+		p.Tag = "v" + flag
+		p.TagSource = "--version (fills the open Version)"
+	default:
+		artifactName := p.DeclaredPath
+		if artifactName == "" {
+			artifactName = p.Dir
+		}
+		p.refuse(Refusal{
+			Headline: fmt.Sprintf("%s declares an identity field that has no value", artifactName),
+			Evidence: [][]string{
+				{"Version", ver.Pos, "declared, never filled"},
+			},
+			Consequence: "This artifact would publish, and every consumer would fail at evaluation\nwith `incomplete value` — a producer's mistake, discoverable only downstream.",
+			Action:      fmt.Sprintf("Supply it:  opm %s version set <version>\n        or: opm %s publish --version <version>", p.Kind, p.Kind),
+		})
+	}
+}
+
+// requireConcreteModulePath refuses when ModulePath is declared but unfilled
+// (msg 1's shape — --version does not apply to it). Absent is refusal 10's
+// finding. Returns the concrete declared path, or "".
+func requireConcreteModulePath(p *Plan) string {
+	mp := p.identityField("ModulePath")
+	if mp == nil || mp.State == StateAbsent {
+		return ""
+	}
+	if mp.State == StateOpen {
+		artifactName := p.Dir
+		p.refuse(Refusal{
+			Headline: fmt.Sprintf("%s declares an identity field that has no value", artifactName),
+			Evidence: [][]string{
+				{"ModulePath", mp.Pos, "declared, never filled"},
+			},
+			Consequence: "There is nothing to derive a registry coordinate from; publish reads the\ndeclared path and refuses to invent one.",
+			Action:      "Declare it in identity/identity.cue:  ModulePath: \"<host>/<path>@v<major>\"",
+		})
+		return ""
+	}
+	return mp.Value
+}
+
+// identityField returns the plan's state for the named field, or nil.
+func (p *Plan) identityField(name string) *IdentityField {
+	for i := range p.Identity {
+		if p.Identity[i].Name == name {
+			return &p.Identity[i]
+		}
+	}
+	return nil
+}

--- a/internal/publish/identity_test.go
+++ b/internal/publish/identity_test.go
@@ -1,0 +1,215 @@
+package publish
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRun_CleanModule_GO pins the clean row of the acceptance matrix: a
+// conformant artifact with concrete identity resolves every coordinate from
+// its own declarations and passes every gate.
+func TestRun_CleanModule_GO(t *testing.T) {
+	p := runFixture(t, KindModule, moduleFiles())
+
+	require.Empty(t, p.Refusals, refusalHeadlines(p))
+	assert.True(t, p.Go())
+	assert.Equal(t, "example.com/modules/demo@v1", p.DeclaredPath)
+	assert.Equal(t, "example.com/modules/demo", p.RegistryRepo)
+	assert.Equal(t, "v1", p.Major)
+	assert.Equal(t, "v1.2.0", p.Tag)
+	assert.Equal(t, "the artifact's own Version", p.TagSource)
+	assert.Empty(t, p.FillVersion)
+
+	ver := p.identityField("Version")
+	require.NotNil(t, ver)
+	assert.Equal(t, StateConcrete, ver.State)
+	assert.Equal(t, "1.2.0", ver.Value)
+	assert.False(t, ver.Defaulted)
+	assert.Contains(t, ver.Pos, "identity/identity.cue:")
+}
+
+func TestRun_CleanCatalog_GO(t *testing.T) {
+	p := runFixture(t, KindCatalog, catalogFiles())
+	require.Empty(t, p.Refusals, refusalHeadlines(p))
+	assert.Equal(t, "example.com/catalogs/demo@v1", p.DeclaredPath)
+	assert.Equal(t, "v1.2.0", p.Tag)
+}
+
+// TestRun_DefaultedVersionIsConcrete pins the defaults-are-concrete decision:
+// `#VersionType | *"1.2.0"` publishes at the default — the committed,
+// release-automation-owned declaration.
+func TestRun_DefaultedVersionIsConcrete(t *testing.T) {
+	files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+ModulePath: "example.com/modules/demo@v1"
+Version:    #VersionType | *"1.2.0"
+`)
+	p := runFixture(t, KindModule, files)
+
+	require.Empty(t, p.Refusals, refusalHeadlines(p))
+	ver := p.identityField("Version")
+	assert.Equal(t, StateConcrete, ver.State)
+	assert.Equal(t, "1.2.0", ver.Value)
+	assert.True(t, ver.Defaulted)
+	assert.Equal(t, "v1.2.0", p.Tag)
+	assert.Contains(t, p.TagSource, "(default)")
+}
+
+// TestRun_VersionStateMatrix covers D3/D12's assert-vs-fill semantics.
+func TestRun_VersionStateMatrix(t *testing.T) {
+	openIdentity := `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+ModulePath: "example.com/modules/demo@v1"
+Version:    #VersionType
+`
+
+	t.Run("concrete plus agreeing flag is a no-op assert", func(t *testing.T) {
+		p := runFixture(t, KindModule, moduleFiles(), func(o *Options) { o.VersionFlag = "1.2.0" })
+		require.Empty(t, p.Refusals, refusalHeadlines(p))
+		assert.Equal(t, "v1.2.0", p.Tag)
+		assert.Empty(t, p.FillVersion)
+	})
+
+	t.Run("concrete plus disagreeing flag refuses, never overwrites", func(t *testing.T) {
+		p := runFixture(t, KindModule, moduleFiles(), func(o *Options) { o.VersionFlag = "1.2.1" })
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		r := p.Refusals[0]
+		assert.Contains(t, r.Headline, "--version disagrees with the version this artifact declares")
+		assert.Contains(t, r.Details(), "1.2.1")
+		assert.Contains(t, r.Details(), "1.2.0")
+		assert.Contains(t, r.Action, "opm module version set 1.2.1")
+	})
+
+	t.Run("open plus flag fills and records the working-tree write", func(t *testing.T) {
+		files := edit(moduleFiles(), "identity/identity.cue", openIdentity)
+		// metadata.version's literal would drift from the filled value.
+		files = edit(files, "module.cue", `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+}
+`)
+		p := runFixture(t, KindModule, files, func(o *Options) { o.VersionFlag = "1.3.0" })
+		require.Empty(t, p.Refusals, refusalHeadlines(p))
+		assert.Equal(t, "v1.3.0", p.Tag)
+		assert.Equal(t, "1.3.0", p.FillVersion)
+		ver := p.identityField("Version")
+		assert.True(t, ver.Filled)
+		assert.Equal(t, StateOpen, ver.State)
+	})
+
+	t.Run("open without flag refuses with the supply actions", func(t *testing.T) {
+		files := edit(moduleFiles(), "identity/identity.cue", openIdentity)
+		p := runFixture(t, KindModule, files)
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		r := p.Refusals[0]
+		assert.Contains(t, r.Headline, "declares an identity field that has no value")
+		assert.Contains(t, r.Details(), "identity/identity.cue:")
+		assert.Contains(t, r.Action, "opm module version set")
+		assert.Contains(t, r.Action, "opm module publish --version")
+	})
+
+	t.Run("absent Version yields exactly one refusal, from unification", func(t *testing.T) {
+		files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+ModulePath: "example.com/modules/demo@v1"
+`)
+		p := runFixture(t, KindModule, files)
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		r := p.Refusals[0]
+		assert.Contains(t, r.Headline, "#IdentityPackage")
+		require.Error(t, r.Err)
+		assert.Contains(t, r.Err.Error(), "Version")
+		// --version does not apply to an absent field: still one refusal.
+		p2 := runFixture(t, KindModule, files, func(o *Options) { o.VersionFlag = "1.2.0" })
+		assert.Len(t, p2.Refusals, 1, refusalHeadlines(p2))
+	})
+}
+
+// TestRun_IdentityConformance covers refusal 10: CUE's own diagnostic, never
+// a hand-rolled comparison.
+func TestRun_IdentityConformance(t *testing.T) {
+	t.Run("conformant identity passes", func(t *testing.T) {
+		p := runFixture(t, KindModule, moduleFiles())
+		assert.Empty(t, p.Refusals, refusalHeadlines(p))
+	})
+
+	t.Run("renamed field refused by closedness", func(t *testing.T) {
+		files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+ModulePath:     "example.com/modules/demo@v1"
+CatalogVersion: "1.2.0"
+`)
+		p := runFixture(t, KindModule, files)
+		require.NotEmpty(t, p.Refusals)
+		found := false
+		for _, r := range p.Refusals {
+			if r.Err != nil && r.Headline == "the identity package does not conform to core's #IdentityPackage" {
+				assert.Contains(t, r.Err.Error(), "CatalogVersion")
+				found = true
+			}
+		}
+		assert.True(t, found, refusalHeadlines(p))
+	})
+
+	t.Run("missing required field refused by unification", func(t *testing.T) {
+		files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+Version: "1.2.0"
+`)
+		p := runFixture(t, KindModule, files)
+		require.NotEmpty(t, p.Refusals)
+		r := p.Refusals[0]
+		require.Error(t, r.Err)
+		assert.Contains(t, r.Err.Error(), "ModulePath")
+	})
+
+	t.Run("absent identity package surfaces the load error", func(t *testing.T) {
+		files := moduleFiles()
+		delete(files, "identity/identity.cue")
+		p := runFixture(t, KindModule, files)
+		require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+		assert.Contains(t, p.Refusals[0].Headline, "identity package does not load")
+		assert.Error(t, p.Refusals[0].Err)
+	})
+}
+
+// TestConformIdentity_IncompleteWordingCanary pins the CUE SDK error wording
+// conformIdentity's filter depends on: openness must keep reading as
+// "incomplete value" so it stays D4's gate rather than a conformance failure.
+// If a cuelang.org/go bump rewords the diagnostic, this fails in CI instead
+// of publish silently misclassifying refusals.
+func TestConformIdentity_IncompleteWordingCanary(t *testing.T) {
+	ctx := cuecontext.New()
+	v := ctx.CompileString(`x: string`).LookupPath(cue.ParsePath("x"))
+	err := v.Validate(cue.Concrete(true))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete value",
+		"cuelang.org/go changed its incompleteness wording — update conformIdentity's filter in identity.go")
+}
+
+// TestRun_LoadFailureShortCircuits: a tree that does not load surfaces the
+// CUE error verbatim and reports nothing identity-derived.
+func TestRun_LoadFailureShortCircuits(t *testing.T) {
+	files := edit(moduleFiles(), "module.cue", `package demo
+
+metadata: name: "demo"
+metadata: name: "other"
+`)
+	p := runFixture(t, KindModule, files)
+	require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+	r := p.Refusals[0]
+	assert.Contains(t, r.Headline, "does not load")
+	require.Error(t, r.Err)
+	assert.Empty(t, p.DeclaredPath)
+	assert.Empty(t, p.Identity)
+}

--- a/internal/publish/load.go
+++ b/internal/publish/load.go
@@ -1,0 +1,235 @@
+package publish
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/load"
+	"cuelang.org/go/cue/parser"
+)
+
+// artifact is the loaded tree: the root package, the identity subpackage,
+// and what cue.mod/module.cue states. cue.Values are retained (never bare
+// decoded structs) so gate refusals can carry Pos().
+type artifact struct {
+	dir string
+
+	// root is the artifact's root package value; rootPkgName its package
+	// clause name and rootPkgPos that clause's position (file:line).
+	root        cue.Value
+	rootPkgName string
+	rootPkgPos  string
+
+	// identity is the ./identity package value.
+	identity cue.Value
+
+	// cueModPath is module.cue's module: line; cueModPos its position.
+	cueModPath string
+	cueModPos  string
+	// sourceKind is module.cue's source.kind ("" when absent).
+	sourceKind string
+	// depVersions maps each cue.mod dependency path (major included) to its
+	// pinned version — what a published artifact resolves.
+	depVersions map[string]string
+}
+
+// loadArtifact loads the root package and the ./identity subpackage from dir
+// with the resolved registry. A load failure is returned as the CUE error
+// verbatim — an artifact that will not load has no readable identity, and
+// reporting anything derived from it would blame the wrong thing.
+func loadArtifact(opts Options) (*artifact, *Refusal) {
+	absDir, err := filepath.Abs(opts.Dir)
+	if err != nil {
+		return nil, &Refusal{Headline: fmt.Sprintf("the artifact directory cannot be resolved: %v", err)}
+	}
+	a := &artifact{dir: absDir}
+
+	root, pkgName, pkgPos, refusal := loadPackage(opts, absDir, ".")
+	if refusal != nil {
+		refusal.Headline = "the artifact does not load, so nothing about it can be judged"
+		return nil, refusal
+	}
+	a.root, a.rootPkgName, a.rootPkgPos = root, pkgName, pkgPos
+
+	identity, _, _, refusal := loadPackage(opts, absDir, "./identity")
+	if refusal != nil {
+		refusal.Headline = "the artifact's identity package does not load, so its identity cannot be read"
+		return nil, refusal
+	}
+	a.identity = identity
+
+	return a, nil
+}
+
+// loadPackage loads one package pattern from dir and returns its built value,
+// package name, and package-clause position.
+func loadPackage(opts Options, dir, pattern string) (val cue.Value, pkgName, pkgPos string, refusal *Refusal) {
+	cfg := &load.Config{
+		Dir: dir,
+		Env: registryEnv(opts.Registry),
+	}
+	insts := load.Instances([]string{pattern}, cfg)
+	if len(insts) == 0 {
+		return cue.Value{}, "", "", &Refusal{Err: fmt.Errorf("no CUE instance found for %s in %s", pattern, dir)}
+	}
+	inst := insts[0]
+	if inst.Err != nil {
+		return cue.Value{}, "", "", &Refusal{Err: inst.Err}
+	}
+	v := opts.Context.BuildInstance(inst)
+	if err := v.Err(); err != nil {
+		return cue.Value{}, "", "", &Refusal{Err: err}
+	}
+
+	pkgName = inst.PkgName
+	for _, f := range inst.Files {
+		if f.PackageName() == pkgName {
+			if pos := packageClausePos(f); pos != "" {
+				pkgPos = relPos(dir, pos)
+				break
+			}
+		}
+	}
+	return v, pkgName, pkgPos, nil
+}
+
+// packageClausePos returns the file:line of a file's package clause.
+func packageClausePos(f *ast.File) string {
+	for _, decl := range f.Decls {
+		if pkg, ok := decl.(*ast.Package); ok {
+			p := pkg.Name.Pos()
+			if p.Filename() == "" {
+				return ""
+			}
+			return fmt.Sprintf("%s:%d", p.Filename(), p.Line())
+		}
+	}
+	return ""
+}
+
+// registryEnv returns the process environment with CUE_REGISTRY overridden
+// when a registry is resolved — no os.Setenv, mirroring the library's schema
+// OCILoader.
+func registryEnv(registry string) []string {
+	env := os.Environ()
+	if registry == "" {
+		return env
+	}
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CUE_REGISTRY=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "CUE_REGISTRY="+registry)
+}
+
+// statArtifactDir resolves dir to an absolute path and requires it to be an
+// existing directory. A typo'd path must surface as a plain not-found error —
+// never as a gate refusal whose action ("opm mod init") cannot possibly help.
+func statArtifactDir(dir string) (string, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolving artifact directory: %w", err)
+	}
+	info, err := os.Stat(absDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("artifact directory %q does not exist", absDir)
+		}
+		return "", fmt.Errorf("accessing artifact directory %q: %w", absDir, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("artifact path %q is not a directory", absDir)
+	}
+	return absDir, nil
+}
+
+// hasCueMod reports whether dir/cue.mod/module.cue exists.
+func hasCueMod(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "cue.mod", "module.cue"))
+	return err == nil
+}
+
+// readCueMod reads cue.mod/module.cue's module: line (with its position),
+// source.kind, and dependency pins into the artifact. Absence of individual
+// fields is not an error here — the gates decide what each absence means.
+func (a *artifact) readCueMod(ctx *cue.Context) error {
+	path := filepath.Join(a.dir, "cue.mod", "module.cue")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	v := ctx.CompileBytes(data, cue.Filename(path))
+	if err := v.Err(); err != nil {
+		return fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	if s, err := v.LookupPath(cue.ParsePath("module")).String(); err == nil {
+		a.cueModPath = s
+	}
+	if s, err := v.LookupPath(cue.ParsePath("source.kind")).String(); err == nil {
+		a.sourceKind = s
+	}
+
+	a.depVersions = map[string]string{}
+	deps := v.LookupPath(cue.ParsePath("deps"))
+	if deps.Exists() {
+		iter, err := deps.Fields()
+		if err == nil {
+			for iter.Next() {
+				depPath := iter.Selector().Unquoted()
+				if ver, err := iter.Value().LookupPath(cue.ParsePath("v")).String(); err == nil {
+					a.depVersions[depPath] = ver
+				}
+			}
+		}
+	}
+
+	// The module: line's position, for msg 2's evidence column.
+	a.cueModPos = relPos(a.dir, moduleLinePos(path, data))
+	return nil
+}
+
+// moduleLinePos parses module.cue and returns the module: field's file:line.
+func moduleLinePos(path string, data []byte) string {
+	f, err := parser.ParseFile(path, data)
+	if err != nil {
+		return path
+	}
+	for _, decl := range f.Decls {
+		field, ok := decl.(*ast.Field)
+		if !ok {
+			continue
+		}
+		if ident, ok := field.Label.(*ast.Ident); ok && ident.Name == "module" {
+			return fmt.Sprintf("%s:%d", path, field.Pos().Line())
+		}
+	}
+	return path
+}
+
+// relPos strips the artifact directory prefix from a file:line position so
+// refusals name paths the way the author sees them.
+func relPos(dir, pos string) string {
+	if pos == "" {
+		return ""
+	}
+	return strings.TrimPrefix(pos, dir+string(filepath.Separator))
+}
+
+// fieldPos returns a cue.Value's declaration position as a dir-relative
+// file:line, or "".
+func fieldPos(dir string, v cue.Value) string {
+	p := v.Pos()
+	if p.Filename() == "" {
+		return ""
+	}
+	return relPos(dir, fmt.Sprintf("%s:%d", p.Filename(), p.Line()))
+}

--- a/internal/publish/plan.go
+++ b/internal/publish/plan.go
@@ -1,0 +1,70 @@
+package publish
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Render prints the resolved plan in experiment 02's measured format: kind,
+// declared path, cue.mod path, repository, major, tag and its source, one
+// line per identity field, the override gate, then the verdict. The plan
+// prints on every invocation before any push — it is #PublishPlan rendered,
+// and it doubles as the dry run.
+//
+// Refusal details are not repeated here; they print through the validation
+// funnel. The verdict line carries the count.
+func (p *Plan) Render() string {
+	var b strings.Builder
+	row := func(label, value string) {
+		if value == "" {
+			value = "—"
+		}
+		fmt.Fprintf(&b, "  %-15s %s\n", label, value)
+	}
+
+	row("kind", string(p.Kind))
+	row("declaredPath", p.DeclaredPath)
+	row("cueModPath", p.CueModPath)
+	row("registryRepo", p.RegistryRepo)
+	row("major", p.Major)
+	row("tag", p.Tag)
+	if p.TagSource != "" {
+		row("tag from", p.TagSource)
+	}
+	for _, f := range p.Identity {
+		state := string(f.State)
+		if f.Defaulted {
+			state += " (default)"
+		}
+		if f.Filled {
+			state += " (filled by --version)"
+		}
+		v := ""
+		if f.Value != "" {
+			v = " = " + f.Value
+		}
+		fmt.Fprintf(&b, "  %-15s %-11s %s%s\n", "identity", f.Name, state, v)
+	}
+	override := fmt.Sprintf("%v", p.OverridePresent)
+	if p.OverrideWaived {
+		override += " (gate waived by --skip-override-check; replacements are ignored either way)"
+	}
+	row("local override", override)
+
+	switch {
+	case p.Go() && p.RegistryChecked:
+		fmt.Fprintf(&b, "\n  GO — pushing %s:%s\n", p.RegistryRepo, p.Tag)
+	case p.Go():
+		// Every local gate passed but the already-published lookup never
+		// completed (registry unreachable): a GO here would be a verdict the
+		// gates never finished earning.
+		fmt.Fprintf(&b, "\n  INCOMPLETE — every local gate passed, but the registry could not be\n  reached for the already-published check; nothing was pushed\n")
+	default:
+		noun := "refusal"
+		if len(p.Refusals) != 1 {
+			noun = "refusals"
+		}
+		fmt.Fprintf(&b, "\n  REFUSED — %d %s\n", len(p.Refusals), noun)
+	}
+	return b.String()
+}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -1,0 +1,178 @@
+// Package publish implements the identity-driven publish pipeline shared by
+// `opm module publish` and `opm catalog publish` (enhancement 0011, slice
+// cli-publish-pipeline).
+//
+// The pipeline derives every coordinate from what the artifact itself
+// declares — decode the tree, read identity/identity.cue, unify it against
+// core's #IdentityPackage, split metadata.modulePath into repository and
+// major — and never edits the artifact to match a coordinate. What is
+// published is exactly the committed tree (D2). Every evaluable gate runs,
+// refusals accumulate into one list, and the resolved plan prints before any
+// push; --dry-run stops after the plan.
+package publish
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/mod/modregistry"
+)
+
+// Kind names the artifact kind being published. The two entry points differ
+// by exactly three predicates: where identity's package name matters, whether
+// the package-name gate applies, and whether the local-override gate can be
+// waived.
+type Kind string
+
+// The two artifact kinds the pipeline publishes.
+const (
+	KindModule  Kind = "module"
+	KindCatalog Kind = "catalog"
+)
+
+// Options carries one publish invocation's inputs.
+type Options struct {
+	// Dir is the artifact tree's root directory (holds cue.mod/ and
+	// identity/).
+	Dir string
+
+	// Kind selects the entry point's differences (package-name gate,
+	// override-gate waiver).
+	Kind Kind
+
+	// Context is the CUE context every load and lookup runs in.
+	Context *cue.Context
+
+	// IdentitySchema is core's #IdentityPackage definition, resolved from the
+	// kernel's schema cache. The identity package is validated by unifying
+	// against it, so CUE produces the diagnostic (refusal 10).
+	IdentitySchema cue.Value
+
+	// Registry is the resolved CUE registry (flag > env > config). Empty
+	// inherits the process environment.
+	Registry string
+
+	// VersionFlag is --version: fills an open identity Version or asserts a
+	// concrete one, never overwrites. Empty means absent.
+	VersionFlag string
+
+	// SkipOverrideCheck waives the local-override gate. Module publish only;
+	// it never changes resolution — replacements are ignored either way.
+	SkipOverrideCheck bool
+}
+
+// IdentityFieldState classifies an identity field per D4's tristate.
+type IdentityFieldState string
+
+// The three states an identity field can be in. Only concrete is publishable;
+// open becomes publishable when --version fills it; absent is a malformed
+// artifact (refusal 10 names it), never fillable.
+const (
+	StateConcrete IdentityFieldState = "concrete"
+	StateOpen     IdentityFieldState = "open"
+	StateAbsent   IdentityFieldState = "absent"
+)
+
+// IdentityField is one identity field's resolved state in the plan.
+type IdentityField struct {
+	// Name is the schema-fixed field name ("ModulePath", "Version").
+	Name string
+	// State is the D4 tristate.
+	State IdentityFieldState
+	// Value is the concrete value, when State is concrete.
+	Value string
+	// Defaulted reports the value came from a CUE default — concrete, with
+	// the default as its value (the committed, release-automation-owned
+	// declaration).
+	Defaulted bool
+	// Filled reports --version is filling this open field on this invocation.
+	Filled bool
+	// Pos is the field's declaration position (file:line), when known.
+	Pos string
+}
+
+// Replacement is one cue.mod/local-module.cue replaceWith entry, reported
+// beside the registry version that supersedes it.
+type Replacement struct {
+	// Path is the replaced dependency's module path, major included.
+	Path string
+	// ReplaceWith is the local directory or fork the working tree points at.
+	ReplaceWith string
+	// PublishedVersion is the version cue.mod/module.cue pins — what the
+	// published artifact will resolve instead. Empty when the dep is not
+	// pinned.
+	PublishedVersion string
+}
+
+// Plan is everything publish resolves before it pushes — 0011's #PublishPlan
+// as data. Every field is derived from the artifact or supplied deliberately;
+// nothing is invented.
+type Plan struct {
+	Kind Kind
+	Dir  string
+
+	// DeclaredPath is the artifact's own identity ModulePath — the complete
+	// CUE module path including the major (read, never composed).
+	DeclaredPath string
+	// CueModPath is cue.mod/module.cue's module: line; CueModPos its position.
+	CueModPath string
+	CueModPos  string
+	// RegistryRepo and Major are DeclaredPath split at "@".
+	RegistryRepo string
+	Major        string
+
+	// Tag is what would be pushed ("v" + effective version); TagSource names
+	// where the version came from.
+	Tag       string
+	TagSource string
+
+	// Identity holds the per-field states.
+	Identity []IdentityField
+
+	// OverridePresent reports cue.mod/local-module.cue exists with
+	// replacements; OverrideWaived that --skip-override-check waived the gate
+	// (modules only). Replacements lists the entries either way.
+	OverridePresent bool
+	OverrideWaived  bool
+	Replacements    []Replacement
+
+	// FillVersion, when non-empty, is the version Push writes into
+	// identity/identity.cue (through internal/cueedit) before zipping — D12:
+	// the fill writes the working tree, because the pushed bytes come from
+	// disk.
+	FillVersion string
+
+	// RegistryChecked reports the already-published lookup completed. When
+	// the registry was unreachable it stays false, and a refusal-free plan
+	// renders INCOMPLETE rather than a GO the gates never finished earning.
+	RegistryChecked bool
+
+	// Refusals is the accumulated refusal list. Empty means GO.
+	Refusals []Refusal
+
+	// registryClient is the client the already-published lookup built,
+	// carried so Push does not resolve registry configuration and
+	// credentials a second time.
+	registryClient *modregistry.Client
+}
+
+// Go reports whether every gate passed.
+func (p *Plan) Go() bool { return len(p.Refusals) == 0 }
+
+// refuse appends a refusal to the plan.
+func (p *Plan) refuse(r Refusal) { p.Refusals = append(p.Refusals, r) }
+
+// ConnectivityError reports the registry could not be reached for a lookup or
+// a push. It is not a refusal: the artifact was never judged. Commands map it
+// to ExitConnectivityError (3).
+type ConnectivityError struct {
+	// Op names the registry operation that failed.
+	Op  string
+	Err error
+}
+
+func (e *ConnectivityError) Error() string {
+	return fmt.Sprintf("registry unreachable: %s: %v", e.Op, e.Err)
+}
+
+func (e *ConnectivityError) Unwrap() error { return e.Err }

--- a/internal/publish/refusal.go
+++ b/internal/publish/refusal.go
@@ -1,0 +1,59 @@
+package publish
+
+import (
+	"strings"
+
+	"github.com/open-platform-model/cli/internal/output"
+)
+
+// Refusal is one gate's refusal in the fixed shape condition → evidence →
+// consequence → action (0011, 06-operational.md). Disagreements print both
+// values in aligned columns naming the file that declares each, and the
+// action is a runnable command, not a description.
+type Refusal struct {
+	// Headline states the condition — the funnel prefixes "error:".
+	Headline string
+
+	// Evidence rows render as aligned columns (label, value, declaring
+	// file:line, …). Nil when the refusal carries a CUE error instead.
+	Evidence [][]string
+
+	// Consequence states what would have been published and what a consumer
+	// would have resolved. Skipped only where genuinely self-evident.
+	Consequence string
+
+	// Action is the runnable command that clears the condition.
+	Action string
+
+	// Err carries CUE's own error for refusals whose diagnostic is CUE's
+	// (refusal 10, load failures) — surfaced through the grouped funnel,
+	// which preserves file:line. When set, the fields above frame it.
+	Err error
+}
+
+// Details renders evidence, consequence, and action as the refusal's detail
+// block, indented for the Details funnel.
+func (r Refusal) Details() string {
+	var parts []string
+	if len(r.Evidence) > 0 {
+		parts = append(parts, output.AlignColumns("  ", r.Evidence))
+	}
+	if r.Consequence != "" {
+		parts = append(parts, indent("  ", r.Consequence))
+	}
+	if r.Action != "" {
+		parts = append(parts, indent("  ", r.Action))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// indent prefixes every line of s with the given indent.
+func indent(prefix, s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		if l != "" {
+			lines[i] = prefix + l
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/publish/registry.go
+++ b/internal/publish/registry.go
@@ -1,0 +1,125 @@
+package publish
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"cuelang.org/go/mod/modconfig"
+	"cuelang.org/go/mod/modregistry"
+	"cuelang.org/go/mod/module"
+	"cuelang.org/go/mod/modzip"
+	"golang.org/x/mod/semver"
+
+	"github.com/open-platform-model/cli/internal/cueedit"
+)
+
+// newRegistryClient builds a module-registry client through the same resolver
+// chain reads use: modconfig routes by CUE registry syntax and layers Docker
+// and Podman credentials under CUE's logins.json, so push and pull share one
+// path (D11). No os.Setenv — the resolved registry rides the config struct.
+func newRegistryClient(registry string) (*modregistry.Client, error) {
+	resolver, err := modconfig.NewResolver(&modconfig.Config{CUERegistry: registry})
+	if err != nil {
+		return nil, fmt.Errorf("resolving registry configuration: %w", err)
+	}
+	return modregistry.NewClientWithResolver(resolver), nil
+}
+
+// gateAlreadyPublished is D15's refusal 8: a published tag names fixed bytes
+// permanently, so publishing over one is refused — no flag or mode turns it
+// into a success. An unreachable registry is a *ConnectivityError, not a
+// refusal: the artifact was never judged.
+func gateAlreadyPublished(ctx context.Context, p *Plan, opts Options) error {
+	if p.DeclaredPath == "" || p.Tag == "" {
+		return nil
+	}
+	client, err := newRegistryClient(opts.Registry)
+	if err != nil {
+		return err
+	}
+	versions, err := client.ModuleVersions(ctx, p.DeclaredPath)
+	if err != nil {
+		return &ConnectivityError{
+			Op:  fmt.Sprintf("listing published versions of %s", p.DeclaredPath),
+			Err: err,
+		}
+	}
+	p.RegistryChecked = true
+	p.registryClient = client
+	for _, v := range versions {
+		if v != p.Tag {
+			continue
+		}
+		p.refuse(Refusal{
+			Headline:    fmt.Sprintf("%s already holds %s", p.DeclaredPath, p.Tag),
+			Consequence: "A published tag names fixed bytes permanently. Publishing cannot replace\nit, and this command will not silently do nothing.",
+			Action:      fmt.Sprintf("Bump and retry:  opm %s version set %s", p.Kind, nextPatch(p.Tag)),
+		})
+		return nil
+	}
+	return nil
+}
+
+// Push publishes the plan: write the --version fill into the working tree
+// when one is pending (D12 — the pushed bytes come from disk), zip the
+// committed directory, and put it through CUE's own module machinery. Callers
+// invoke it only on a GO plan outside --dry-run.
+func Push(ctx context.Context, opts Options, p *Plan) error {
+	if !p.Go() {
+		return fmt.Errorf("internal error: push invoked on a refused plan")
+	}
+	if p.FillVersion != "" {
+		if err := cueedit.SetIdentityVersion(p.Dir, p.FillVersion); err != nil {
+			return fmt.Errorf("filling identity Version: %w", err)
+		}
+	}
+
+	mv, err := module.NewVersion(p.DeclaredPath, p.Tag)
+	if err != nil {
+		return fmt.Errorf("forming module version from %s and %s: %w", p.DeclaredPath, p.Tag, err)
+	}
+
+	zipFile, err := os.CreateTemp("", "opm-publish-*.zip")
+	if err != nil {
+		return fmt.Errorf("creating zip staging file: %w", err)
+	}
+	defer func() {
+		zipFile.Close()
+		os.Remove(zipFile.Name())
+	}()
+
+	if err := modzip.CreateFromDir(zipFile, mv, p.Dir); err != nil {
+		return fmt.Errorf("zipping %s: %w", p.Dir, err)
+	}
+	info, err := zipFile.Stat()
+	if err != nil {
+		return fmt.Errorf("reading zip staging file: %w", err)
+	}
+
+	client := p.registryClient
+	if client == nil {
+		if client, err = newRegistryClient(opts.Registry); err != nil {
+			return err
+		}
+	}
+	if err := client.PutModule(ctx, mv, zipFile, info.Size()); err != nil {
+		return &ConnectivityError{
+			Op:  fmt.Sprintf("pushing %s:%s", p.RegistryRepo, p.Tag),
+			Err: err,
+		}
+	}
+	return nil
+}
+
+// nextPatch suggests the patch bump after tag for refusal 8's action.
+func nextPatch(tag string) string {
+	if !semver.IsValid(tag) {
+		return "<next-version>"
+	}
+	var major, minor, patch int
+	if _, err := fmt.Sscanf(semver.Canonical(tag), "v%d.%d.%d", &major, &minor, &patch); err != nil {
+		return "<next-version>"
+	}
+	return fmt.Sprintf("%d.%d.%d", major, minor, patch+1)
+}

--- a/internal/publish/registry_test.go
+++ b/internal/publish/registry_test.go
@@ -1,0 +1,302 @@
+package publish
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cuelabs.dev/go/oci/ociregistry/ocimem"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/mod/modregistrytest"
+	"cuelang.org/go/mod/module"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pushFixture runs the pipeline to GO and pushes, returning the plan and the
+// options used.
+func pushFixture(t *testing.T, registry string, files map[string]string) (*Plan, Options) {
+	t.Helper()
+	dir := writeTree(t, files)
+	var opts Options
+	p := runDir(t, KindModule, dir, func(o *Options) {
+		o.Registry = registry
+		opts = *o
+	})
+	require.True(t, p.Go(), refusalHeadlines(p))
+	require.NoError(t, Push(context.Background(), opts, p))
+	return p, opts
+}
+
+func TestGate_AlreadyPublished(t *testing.T) {
+	registry := emptyTestRegistry(t)
+	files := moduleFiles()
+	_, opts := pushFixture(t, registry, files)
+
+	// The same tree at the same version: the lookup finds the tag and
+	// refuses. No flag or mode turns this into a success — there is none to
+	// pass.
+	p2, err := Run(context.Background(), opts)
+	require.NoError(t, err)
+	require.Len(t, p2.Refusals, 1, refusalHeadlines(p2))
+	r := p2.Refusals[0]
+	assert.Contains(t, r.Headline, "example.com/modules/demo@v1 already holds v1.2.0")
+	assert.Contains(t, r.Consequence, "fixed bytes permanently")
+	assert.Contains(t, r.Action, "opm module version set 1.2.1")
+}
+
+func TestGate_AlreadyPublished_UnreachableRegistryIsConnectivity(t *testing.T) {
+	// A port nothing listens on: the lookup fails to connect, which is a
+	// connectivity error, never a refusal.
+	unreachable := func(t *testing.T, files map[string]string) (*Plan, error) {
+		t.Helper()
+		dir := writeTree(t, files)
+		cueCtx := cuecontext.New()
+		return Run(context.Background(), Options{
+			Dir:            dir,
+			Kind:           KindModule,
+			Context:        cueCtx,
+			IdentitySchema: stubSchema(t, cueCtx),
+			Registry:       "127.0.0.1:1+insecure",
+			// The override refusal below must not be waived.
+		})
+	}
+
+	t.Run("clean tree renders INCOMPLETE, never GO", func(t *testing.T) {
+		p, err := unreachable(t, moduleFiles())
+		require.Error(t, err)
+		var connErr *ConnectivityError
+		require.ErrorAs(t, err, &connErr)
+		assert.Contains(t, connErr.Error(), "listing published versions")
+
+		// The plan is still returned and renders an incomplete verdict — a
+		// GO here would be one the gates never finished earning.
+		require.NotNil(t, p)
+		assert.True(t, p.Go())
+		assert.False(t, p.RegistryChecked)
+		assert.Contains(t, p.Render(), "INCOMPLETE")
+		assert.NotContains(t, p.Render(), "GO —")
+	})
+
+	t.Run("locally-derived refusals survive the connectivity failure", func(t *testing.T) {
+		files := edit(moduleFiles(), "cue.mod/module.cue", `module: "example.com/modules/demo@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+deps: "example.com/dep@v1": v: "v1.4.0"
+`)
+		files = edit(files, "cue.mod/local-module.cue", `deps: "example.com/dep@v1": replaceWith: "../dep"
+`)
+		p, err := unreachable(t, files)
+		require.Error(t, err)
+		require.NotNil(t, p)
+		// The offline author still sees the problem they can fix right now.
+		assert.Contains(t, refusalHeadlines(p), "local-module.cue is present")
+		assert.Contains(t, p.Render(), "REFUSED")
+	})
+}
+
+// TestRun_NonexistentDirIsAnError: a typo'd path must be a plain not-found
+// error — never refusal msg 3, whose "opm mod init" action cannot help.
+func TestRun_NonexistentDirIsAnError(t *testing.T) {
+	cueCtx := cuecontext.New()
+	opts := Options{
+		Dir:            filepath.Join(t.TempDir(), "no-such-module"),
+		Kind:           KindModule,
+		Context:        cueCtx,
+		IdentitySchema: stubSchema(t, cueCtx),
+	}
+
+	p, err := Run(context.Background(), opts)
+	require.Error(t, err)
+	assert.Nil(t, p)
+	assert.Contains(t, err.Error(), "does not exist")
+
+	_, _, err = VetChecks(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+// TestPush_OverrideNeverBakedIn pins the mechanism behind D6's "replacements
+// are ignored either way": modzip omits cue.mod/local-module.cue from the
+// created zip, so the published artifact can only resolve published deps.
+func TestPush_OverrideNeverBakedIn(t *testing.T) {
+	registry := emptyTestRegistry(t)
+	files := edit(moduleFiles(), "cue.mod/module.cue", `module: "example.com/modules/demo@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+deps: "example.com/dep@v1": v: "v1.4.0"
+`)
+	files = edit(files, "cue.mod/local-module.cue", `deps: "example.com/dep@v1": replaceWith: "../dep"
+`)
+	dir := writeTree(t, files)
+	var opts Options
+	p := runDir(t, KindModule, dir, func(o *Options) {
+		o.Registry = registry
+		o.SkipOverrideCheck = true
+		opts = *o
+	})
+	require.True(t, p.Go(), refusalHeadlines(p))
+	require.True(t, p.OverrideWaived)
+	require.NoError(t, Push(context.Background(), opts, p))
+
+	client, err := newRegistryClient(opts.Registry)
+	require.NoError(t, err)
+	mv, err := module.NewVersion(p.DeclaredPath, p.Tag)
+	require.NoError(t, err)
+	m, err := client.GetModule(context.Background(), mv)
+	require.NoError(t, err)
+
+	names := publishedNames(t, m.GetZip)
+	assert.NotContains(t, names, "cue.mod/local-module.cue")
+	// The published cue.mod still pins the registry dependency the artifact
+	// will resolve.
+	modFile := publishedFile(t, m.GetZip, "cue.mod/module.cue")
+	assert.Contains(t, modFile, `"example.com/dep@v1"`)
+	assert.Contains(t, modFile, "v1.4.0")
+}
+
+// TestPush_RoundTrip publishes and resolves the module back: the published
+// bytes are the committed tree (D2), identity file included.
+func TestPush_RoundTrip(t *testing.T) {
+	registry := emptyTestRegistry(t)
+	files := moduleFiles()
+	p, opts := pushFixture(t, registry, files)
+
+	client, err := newRegistryClient(opts.Registry)
+	require.NoError(t, err)
+	mv, err := module.NewVersion(p.DeclaredPath, p.Tag)
+	require.NoError(t, err)
+
+	m, err := client.GetModule(context.Background(), mv)
+	require.NoError(t, err)
+
+	modFile, err := m.ModuleFile(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, string(modFile), `"example.com/modules/demo@v1"`)
+
+	identity := publishedFile(t, m.GetZip, "identity/identity.cue")
+	assert.Equal(t, files["identity/identity.cue"], identity)
+}
+
+// TestPush_WritesVersionFillBeforeZipping: an open Version filled by
+// --version reaches both the working tree and the published bytes — an
+// in-memory overlay would publish bytes the tree does not hold.
+func TestPush_WritesVersionFillBeforeZipping(t *testing.T) {
+	registry := emptyTestRegistry(t)
+	files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+"
+
+ModulePath: "example.com/modules/demo@v1"
+Version:    #VersionType
+`)
+	files = edit(files, "module.cue", `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+}
+`)
+	dir := writeTree(t, files)
+	var opts Options
+	p := runDir(t, KindModule, dir, func(o *Options) {
+		o.Registry = registry
+		o.VersionFlag = "1.3.0"
+		opts = *o
+	})
+	require.True(t, p.Go(), refusalHeadlines(p))
+	require.Equal(t, "1.3.0", p.FillVersion)
+	require.NoError(t, Push(context.Background(), opts, p))
+
+	// The working tree was written (D12)…
+	onDisk, err := os.ReadFile(filepath.Join(dir, "identity", "identity.cue"))
+	require.NoError(t, err)
+	assert.Contains(t, string(onDisk), `#VersionType & "1.3.0"`)
+
+	// …and the published bytes are that written tree.
+	client, err := newRegistryClient(opts.Registry)
+	require.NoError(t, err)
+	mv, err := module.NewVersion("example.com/modules/demo@v1", "v1.3.0")
+	require.NoError(t, err)
+	m, err := client.GetModule(context.Background(), mv)
+	require.NoError(t, err)
+	published := publishedFile(t, m.GetZip, "identity/identity.cue")
+	assert.Equal(t, string(onDisk), published)
+}
+
+// TestPush_Authenticated pushes through modconfig's credential chain against
+// a registry requiring basic auth — push and pull share one resolver path
+// (D11), so `docker login` is all CI needs.
+func TestPush_Authenticated(t *testing.T) {
+	reg, err := modregistrytest.NewServer(
+		ocimem.NewWithConfig(&ocimem.Config{ImmutableTags: true}),
+		&modregistrytest.AuthConfig{Username: "opm", Password: "sesame"},
+	)
+	require.NoError(t, err)
+	t.Cleanup(reg.Close)
+
+	// Credentials arrive the way docker login leaves them.
+	dockerDir := t.TempDir()
+	auth := base64.StdEncoding.EncodeToString([]byte("opm:sesame"))
+	cfg := map[string]any{"auths": map[string]any{reg.Host(): map[string]string{"auth": auth}}}
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dockerDir, "config.json"), data, 0o600))
+	t.Setenv("DOCKER_CONFIG", dockerDir)
+
+	registry := reg.Host() + "+insecure"
+	p, _ := pushFixture(t, registry, moduleFiles())
+	assert.Equal(t, "v1.2.0", p.Tag)
+}
+
+// publishedFile reads one file out of a published module zip.
+func publishedFile(t *testing.T, getZip func(context.Context) (io.ReadCloser, error), name string) string {
+	t.Helper()
+	rc, err := getZip(context.Background())
+	require.NoError(t, err)
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	for _, f := range zr.File {
+		if f.Name != name {
+			continue
+		}
+		r, err := f.Open()
+		require.NoError(t, err)
+		content, err := io.ReadAll(r)
+		require.NoError(t, r.Close())
+		require.NoError(t, err)
+		return string(content)
+	}
+	t.Fatalf("file %s not found in published zip (have %v)", name, fileNames(zr))
+	return ""
+}
+
+// publishedNames lists every file name in a published module zip.
+func publishedNames(t *testing.T, getZip func(context.Context) (io.ReadCloser, error)) []string {
+	t.Helper()
+	rc, err := getZip(context.Background())
+	require.NoError(t, err)
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	return fileNames(zr)
+}
+
+func fileNames(zr *zip.Reader) []string {
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	return names
+}

--- a/internal/publish/vet.go
+++ b/internal/publish/vet.go
@@ -1,0 +1,84 @@
+package publish
+
+import (
+	"fmt"
+	"strings"
+
+	"cuelang.org/go/cue"
+)
+
+// VetChecks runs the subset of the publish gates `opm module vet` shares with
+// publish (D16, D18, D21): identity conformance against #IdentityPackage,
+// metadata ↔ identity derivation, cue.mod ↔ declared-path agreement, and the
+// version-major/path-major half of the tag rule. Concreteness is deliberately
+// not enforced — an open Version is a valid authoring state; publish is where
+// it must be filled.
+//
+// Returns the plan (check failures accumulate as refusals), and the loaded
+// module root value so the caller can continue into values validation without
+// a second load. A root that does not load is returned as an error — the
+// existing vet load-failure class — while a missing or broken identity
+// package is a check refusal.
+func VetChecks(opts Options) (*Plan, cue.Value, error) {
+	if opts.Context == nil {
+		return nil, cue.Value{}, fmt.Errorf("publish: Options.Context is required")
+	}
+	if !opts.IdentitySchema.Exists() {
+		return nil, cue.Value{}, fmt.Errorf("publish: Options.IdentitySchema is required")
+	}
+	absDir, err := statArtifactDir(opts.Dir)
+	if err != nil {
+		return nil, cue.Value{}, err
+	}
+
+	p := &Plan{Kind: opts.Kind, Dir: absDir}
+
+	if !hasCueMod(absDir) {
+		p.refuse(noCueModRefusal(opts, absDir))
+		return p, cue.Value{}, nil
+	}
+
+	root, pkgName, pkgPos, refusal := loadPackage(opts, absDir, ".")
+	if refusal != nil {
+		return nil, cue.Value{}, fmt.Errorf("loading module package from %s: %w", absDir, refusal.Err)
+	}
+	a := &artifact{dir: absDir, root: root, rootPkgName: pkgName, rootPkgPos: pkgPos}
+
+	identity, _, _, refusal := loadPackage(opts, absDir, "./identity")
+	if refusal != nil {
+		p.refuse(Refusal{
+			Headline: "the module's identity package does not load, so its identity cannot be checked",
+			Err:      refusal.Err,
+		})
+		return p, root, nil
+	}
+	a.identity = identity
+
+	if err := a.readCueMod(opts.Context); err != nil {
+		p.refuse(Refusal{Headline: "cue.mod/module.cue cannot be read", Err: err})
+		return p, root, nil //nolint:nilerr // the read failure IS the refusal; the plan carries it
+	}
+	p.CueModPath, p.CueModPos = a.cueModPath, a.cueModPos
+
+	if r := conformIdentity(a, opts.IdentitySchema); r != nil {
+		p.refuse(*r)
+	}
+	p.Identity = identityStates(a)
+	p.DeclaredPath = requireConcreteModulePath(p)
+	if before, after, ok := strings.Cut(p.DeclaredPath, "@"); ok {
+		p.RegistryRepo, p.Major = before, after
+	}
+
+	// D18's evaluable half at vet: no tag argument exists, so the check is
+	// that the declared version's major names the path's.
+	if ver := p.identityField("Version"); ver != nil && ver.State == StateConcrete {
+		p.Tag = "v" + ver.Value
+		p.TagSource = "the artifact's own Version"
+		gateTagMajor(p)
+	}
+
+	gateCueModAgreement(p, a)
+	gateDerivation(p, a)
+
+	return p, root, nil
+}

--- a/internal/publish/vet_test.go
+++ b/internal/publish/vet_test.go
@@ -1,0 +1,116 @@
+package publish
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runVetChecks runs VetChecks on files with the stub schema. None of the
+// fixtures declare debugValues — the checks must report regardless.
+func runVetChecks(t *testing.T, files map[string]string) *Plan {
+	t.Helper()
+	dir := writeTree(t, files)
+	ctx := cuecontext.New()
+	p, root, err := VetChecks(Options{
+		Dir:            dir,
+		Kind:           KindModule,
+		Context:        ctx,
+		IdentitySchema: stubSchema(t, ctx),
+	})
+	require.NoError(t, err)
+	require.True(t, root.Exists())
+	return p
+}
+
+func TestVetChecks_CleanModulePasses(t *testing.T) {
+	p := runVetChecks(t, moduleFiles())
+	assert.Empty(t, p.Refusals, refusalHeadlines(p))
+	assert.Equal(t, "example.com/modules/demo@v1", p.DeclaredPath)
+}
+
+func TestVetChecks_CoordinateDrift(t *testing.T) {
+	files := edit(moduleFiles(), "cue.mod/module.cue", `module: "example.com/modules/other@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+`)
+	p := runVetChecks(t, files)
+	require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+	r := p.Refusals[0]
+	assert.Contains(t, r.Headline, "disagrees with itself about where it lives")
+	// The same aligned two-value form publish uses: both values, both files.
+	assert.Contains(t, r.Details(), "example.com/modules/demo@v1")
+	assert.Contains(t, r.Details(), "example.com/modules/other@v1")
+}
+
+func TestVetChecks_DerivationDrift(t *testing.T) {
+	files := edit(moduleFiles(), "module.cue", `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+	version:    "1.0.0"
+}
+`)
+	p := runVetChecks(t, files)
+	require.Len(t, p.Refusals, 1, refusalHeadlines(p))
+	assert.Contains(t, p.Refusals[0].Headline, "states a version its identity package does not")
+	assert.Contains(t, p.Refusals[0].Action, "version: id.Version")
+}
+
+func TestVetChecks_NonConformantIdentity(t *testing.T) {
+	files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+ModulePath:     "example.com/modules/demo@v1"
+CatalogVersion: "1.2.0"
+`)
+	p := runVetChecks(t, files)
+	require.NotEmpty(t, p.Refusals)
+	r := p.Refusals[0]
+	assert.Contains(t, r.Headline, "#IdentityPackage")
+	require.Error(t, r.Err)
+	assert.Contains(t, r.Err.Error(), "CatalogVersion")
+}
+
+// TestVetChecks_OpenVersionIsNotPoliced: an open Version is a valid authoring
+// state; vet does not enforce concreteness — publish does.
+func TestVetChecks_OpenVersionIsNotPoliced(t *testing.T) {
+	files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+"
+
+ModulePath: "example.com/modules/demo@v1"
+Version:    #VersionType
+`)
+	files = edit(files, "module.cue", `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+}
+`)
+	p := runVetChecks(t, files)
+	assert.Empty(t, p.Refusals, refusalHeadlines(p))
+}
+
+// TestVetChecks_VersionMajorSkew: D18's evaluable half at vet — the declared
+// version's major must name the path's.
+func TestVetChecks_VersionMajorSkew(t *testing.T) {
+	files := edit(moduleFiles(), "identity/identity.cue", `package identity
+
+ModulePath: "example.com/modules/demo@v1"
+Version:    "2.0.0"
+`)
+	files = edit(files, "module.cue", `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+	version:    "2.0.0"
+}
+`)
+	p := runVetChecks(t, files)
+	assert.Contains(t, refusalHeadlines(p), "within the major")
+}

--- a/openspec/changes/archive/2026-08-16-cli-publish-pipeline/design.md
+++ b/openspec/changes/archive/2026-08-16-cli-publish-pipeline/design.md
@@ -1,0 +1,101 @@
+# Design — cli-publish-pipeline
+
+## Overview
+
+One pipeline in `internal/publish`, two thin commands. The pipeline is a Go rendering of 0011's `#PublishPlan` (`schemas/target.cue` — the slice's specification, not a second enforcement point), with the gate semantics fixed by decisions D1–D21 and the message shapes fixed verbatim by `06-operational.md`. The reference implementation is experiment `02-publish-plan-gates` (14 measured verdicts), corrected for two known stalenesses: the flag is `--skip-override-check` (not the experiment's spelling), and modules now carry `identity/identity.cue` with `Version` (D12 reversed the experiment's D2-era module shape).
+
+```
+opm module publish [dir] [--version X] [--skip-override-check] [--dry-run]
+opm catalog publish [dir] [--version X] [--dry-run]
+        │
+        ▼
+ internal/publish
+   1 load       root package + ./identity subpackage (load error surfaces as-is)
+   2 identity   unify against core.#IdentityPackage (schema cache) — refusal 10
+   3 derive     declaredPath = id.ModulePath (READ; split → repo, major)
+                effective version = declared | --version-filled ; tag = "v"+effective
+   4 gates      accumulate refusals (see table); print plan
+   5 push       modzip.CreateFromDir → modregistry.PutModule   (skipped on --dry-run
+                                                                or any refusal)
+```
+
+## Research & Decisions
+
+### Push mechanism: public CUE SDK, in-process
+
+**Context**: 0011 says only "CUE performs the push"; no API is named anywhere in the enhancement.
+**Explored**: `cue mod publish`'s implementation vs the public surface at cuelang.org/go v0.17.1 (the CLI's exact pin).
+**Options considered**:
+1. Shell out to the `cue` binary — inherits everything, but resurrects the unimplemented `cue-binary-integration` change's discovery/version-skew problem and makes credentials/registry routing opaque to our error shaping.
+2. In-process via public API — `modconfig.NewResolver(&modconfig.Config{CUERegistry: cfg.Registry})` → `modregistry.NewClientWithResolver` → `modzip.CreateFromDir` → `PutModule`. Everything is exported; credentials arrive free (the resolver's transport layers Docker/Podman config under CUE's `logins.json` — push and pull share one path, which is D11's whole argument); `CUERegistry` on the config struct means no `os.Setenv` (improving on the legacy env-mutation loader).
+**Decision**: Option 2.
+**Rationale**: pure Go, testable against the public in-process `modregistrytest` (immutable tags + auth), registry routing through `ResolveRegistry` precedence exactly like every other command, and our refusal messages stay ours. Two `cue mod publish` behaviors are handled explicitly rather than inherited:
+- **`source:` preflight** — publish requires `cue.mod`'s `source: {kind: "self"}` (both shipped trees carry it; `self` selects the whole-directory zip with no VCS machinery). Absent/other → a refusal in the house shape pointing at `cue mod edit --source self`. (Experiment 02's one push-mechanism finding, now a gate instead of a late CUE error.)
+- **Tidiness** — `modload.CheckTidy` is internal and is NOT reproduced. The pipeline's full decode (root + identity, resolved against the configured registry) already refuses the failure class that matters (unresolvable dependency tree); extraneous-dep hygiene remains `cue mod tidy`'s job in the authoring flow. Recorded as a deviation in 0011 on landing. `cue-binary-integration` stays unimplemented and un-absorbed — publish does not need the binary.
+
+### The `--version` writer lands here as `internal/cueedit`
+
+**Context**: refusal 1's action offers `opm catalog publish --version 1.3.0`; D12 says `--version` fills an *open* field by **writing the working tree** (D2: what is published is what is committed — an in-memory overlay would publish bytes the tree doesn't hold, since `modzip.CreateFromDir` ships what is on disk). But the surgical AST rewrite is `cli-authoring-commands`' mechanism (D8: locate `Version` by the schema-fixed path, preserve comments/alignment, rebuild the `&` chain).
+**Decision**: a minimal `internal/cueedit` package implementing exactly D8's Version rewrite lands in this slice; `--version` fill uses it; `cli-authoring-commands` builds `version set` (and `mod init` repair) on it. Assert-vs-fill semantics per D3/D12: concrete field + agreeing flag → no-op; concrete + disagreeing → refusal 5; open + flag → write, then proceed with the written value; open + no flag → refusal 1.
+**Rationale**: the alternative (assert-only until the sibling slice lands) ships refusal messages whose actions don't work — the messages are normative. Implementation-here/commands-there mirrors the accepted `StripProvenance` precedent. Recorded as a boundary adjustment in 0011 on landing.
+
+### Identity states: `absent` / `open` / `concrete`, with defaults counting as concrete
+
+**Context**: D4's tristate; but the shipped catalog identity declares `Version: #VersionType | *"2.0.0-alpha.3"` (release-please owns the default) — neither literal-concrete nor open.
+**Decision**: the pipeline evaluates with CUE defaults; a defaulted field is **concrete** with the default as its value (that is the committed, release-automation-owned declaration — publishing it is the intended flow today). `open` = no value and no default (the D3 authoring posture); `absent` = the field or file missing at the schema-fixed path — never publishable, `--version` does not apply (a malformed artifact, not an unfinished one; refusal 10's unification error names it). One cause, one refusal: the absent path must not also report "no version available" (experiment 02's double-refusal fix).
+
+### Gate inventory, evaluation order, and accumulation
+
+Gates run in dependency order; everything evaluable is evaluated and refusals accumulate into a single list (experiment 02: "a refusal list beats a single error"). A tree that fails step 1 short-circuits — nothing downstream is evaluable, and the load error is surfaced verbatim ("blaming the wrong thing" fix).
+
+| # | Gate | Decision | Refusal |
+|---|---|---|---|
+| 1 | tree + identity package load | — | load error verbatim |
+| 2 | no `cue.mod` | D16 | msg 3 (points at `opm mod init`) |
+| 3 | `source: {kind:"self"}` present | (mechanism) | new msg, house shape |
+| 4 | identity conforms to `#IdentityPackage` | D21 | msg 10 = CUE's unification error through the grouped-error funnel |
+| 5 | identity fields concrete (post `--version`) | D4/D3/D12 | msgs 1, 5 |
+| 6 | `metadata.*` derives from `id.*` | D12 | msg 7 |
+| 7 | `cue.mod` `module:` == declared path | D16 | msg 2 |
+| 8 | module package name == `metadata.name` | D1 | new msg, house shape (drafted below) |
+| 9 | tag == effective version; tag major == path major | D18 / `#TagRef` | msg 6 |
+| 10 | namespace + kind segment (owned domains only) | D13/D14/D1 | `_kindAgrees` refusal, house shape |
+| 11 | `local-module.cue` presence | D6 | msgs 4a/4b (`--skip-override-check`, module only) |
+| 12 | tag not already published (registry lookup via `modregistry.Client.ModuleVersions`) | D15 | msg 8 |
+
+Gate 12 is the only registry round-trip before the push; unreachable registry there is a connectivity error (exit 3), not a refusal.
+
+**The drafted package-name refusal (gate 8 — no message exists in 06-operational; flag for a 0011 history note):**
+
+```
+error: modules/postgres's package does not bind to its name
+  package    postgres_db    modules/postgres/module.cue:1
+  name       postgres       modules/postgres/identity — via metadata.name
+
+  A consumer's bare `import "opmodel.dev/modules/postgres@v2"` binds the package
+  name; when they differ every consumer must alias the import.
+
+  Rename the package:  package postgres
+```
+
+### Plan output and `--dry-run`
+
+The plan prints on **every** invocation before any push (it is `#PublishPlan` rendered; experiment 02's format: kind, declared path, cue.mod path, repo, major, tag + tag source, one line per identity field with state/source/value, override gate, then `GO — pushing <repo>:<tag>` or `REFUSED` + the accumulated list). `--dry-run` stops after the plan with exit 0 on GO and exit 2 on REFUSED — the dry run runs *all* gates including the already-published lookup (the thin-editor preview precedent: a dry run surfaces rejections, never defers them). No `--check`, no JSON (future; `#PublishPlan` is the schema it would serialize).
+
+### Exit codes and error display
+
+`ExitSuccess 0` / any refusal `ExitValidationError 2` (status-exit-codes precedent: ran fine, result is bad) / registry unreachable `ExitConnectivityError 3` / unexpected `1`. Refusals print through the existing `PrintValidationError` funnel: messages 1–8 as `ValidationError` with details (aligned two-value columns via a new small `output` helper — `Table` is header-oriented and wrong for this); message 10 relies on the funnel's grouped-CUE-error path, which preserves `file:line`. Positions for messages 1/2/5/6/7 come from `cue.Value.Pos()` on `LookupPath` results — the identity loader keeps `cue.Value`s, never bare decoded structs.
+
+### `opm module vet` checks and cfg threading
+
+Vet currently drops `cfg` entirely, so its loads ignore the resolved registry — fixed here (constructor threads `cfg`; the load path gains the registry). D16 (coordinate agreement), D18 (tag/version agreement — against the declared version; vet has no tag argument, so the check is the derivation/major half), and D21 (identity conformance) run between module load and the values stanza, so a module with no `debugValues` still reports coordinate drift. Output via `FormatVetCheck` lines consistent with existing vet rendering. No `opm catalog vet` in this slice: catalog-side checks run inside `catalog publish` (and its `--dry-run`); a standalone catalog vet is noted for `cli-catalog-gates`.
+
+### Test strategy
+
+In-process registry on the **public** `modregistrytest` (`ocimem` with `ImmutableTags: true` — D15's already-published refusal and immutability are testable hermetically; `NewServer` with `AuthConfig` covers the authenticated-push path). The library's internal `registrytest` is not importable and is not copied — the CLI's harness builds the minimal module/catalog trees it needs as `txtar`-style fixtures. The acceptance matrix is experiment 02's 14-row verdict table, re-derived for D12's module shape (modules now have identity subpackages — the module rows become the same two-row table as catalogs) and D6's flag spelling, plus: defaulted-version concreteness, package-name rule, `source:` preflight, already-published (immutable registry), push-success round-trip (publish then resolve back).
+
+## Open questions (carried, not blocking)
+
+- Whether the plan gains `--json` when the cutover slices script against it (schema exists; deferred YAGNI).
+- The git-sourced "you forgot to bump" *warning* (D15) remains unowned by any slice — not implemented here.
+- Aligned-column rendering may want promotion into `output` as a general two-value-disagreement helper if `cli-catalog-gates` reuses it (likely).

--- a/openspec/changes/archive/2026-08-16-cli-publish-pipeline/proposal.md
+++ b/openspec/changes/archive/2026-08-16-cli-publish-pipeline/proposal.md
@@ -1,0 +1,42 @@
+# Proposal — cli-publish-pipeline
+
+> Slice `cli-publish-pipeline` of enhancement `0011` (Module and Catalog Publishing). Decisions D1, D2, D4, D6, D12, D15, D16, D18, D21. Depends on `0011:core-identity-package` (done — `#IdentityPackage` ships in core v2) and `0010:cli-coordinate-adoption` (done — the CLI builds on the core-v2 library line).
+
+## Why
+
+Nothing today can publish an OPM artifact from its committed source. The catalog releases through a copy-and-stamp task (rsync `src/` to a build dir, write a `version_override.cue` into the copy, publish the copy — the committed tree and the published bytes are different trees), and the module fleet published through a checksum ledger that never read or wrote the module's own version — measured: `jellyfin` `v2.0.1` and `v2.0.2` both shipped metadata claiming `2.0.0`, giving three non-authoritative answers to "what version is this", and a CLI-deployed instance recorded a version the operator then resolved to a *different artifact*, reconciling it green forever.
+
+Enhancement 0011's answer is one publish pipeline with two entry points — `opm module publish` and `opm catalog publish` — that derives coordinates from the artifact's identity instead of rewriting the artifact to match a coordinate: decode, read `identity/identity.cue`, unify it against core's shipped `#IdentityPackage` (CUE produces the diagnostic — refusal 10), derive path/repo/major/tag by reading and splitting `metadata.modulePath`, run the gates, push. What is published is what is committed (D2). Both CI cutover slices (`catalogs-publish-cutover`, `modules-publish-cutover`) and 0010's two republish migrations wait behind this slice; `cli-catalog-gates` builds its compatibility and member gates on this pipeline.
+
+This slice also lands a check that has never existed anywhere: the version-major/path-major agreement (`#IdentityPackage.VersionMajor`) — core deleted its own assertions of that relation citing publish-side validation (0010 D43/D45), so until this pipeline runs, the relation is enforced by nothing.
+
+## What Changes
+
+- **New command group `opm catalog`** (first in the repo) with `opm catalog publish`; **new `opm module publish`**. Both are thin cobra wrappers over one new `internal/publish` package (Constitution II: commands orchestrate).
+- **The pipeline**: load the artifact tree and its `identity/` subpackage (a tree that does not load surfaces the load error — never "identity absent"); unify the identity package against `core.#IdentityPackage` from the kernel's schema cache; verify `metadata.{modulePath,version}` derive from `id.{ModulePath,Version}` (D12); check `cue.mod`'s `module:` line against the declared path (D16); derive `registryRepo`/`major`/`tag` by splitting the declared path; enforce tag == effective declared version (D18) and the module package-name rule (D1); detect `cue.mod/local-module.cue` (D6 — modules may waive the *gate* with `--skip-override-check`, catalogs never; replacements are ignored either way); refuse an already-published tag via a registry lookup (D15 — no skip mode exists); push via CUE's own machinery.
+- **Refusals 1–8 and 10** exactly as drafted in 0011 `06-operational.md`: fixed condition → evidence → consequence → action shape, aligned two-value columns naming the file that declares each value, actions as runnable commands, `file:line` positions carried through decode. All evaluable gates run and refusals accumulate into one list (one pass fixes everything); one cause yields one refusal.
+- **Plan output = the dry run** (D16: no separate `--check`): every publish prints the resolved plan (kind, declared path, cue.mod path, repo, major, tag and its source, per-field identity state, override gate) before pushing; `--dry-run` stops after the plan. The rendering follows 0011 experiment 02's measured format.
+- **`--version` on both commands**: fills an open identity field or asserts a concrete one, never overwrites (refusal 5). The fill writes the working tree (D12) through a new minimal `internal/cueedit` writer implementing D8's schema-fixed-path surgical rewrite — the mechanism `cli-authoring-commands` will reuse for `version set` (implementation here, command surface there; same pattern as the library's `StripProvenance` precedent).
+- **`opm module vet` gains the D16 and D18 checks** (coordinate agreement, tag/version agreement, identity conformance) before its values stanza — which requires finally threading `cfg` into vet so its loads respect the resolved registry.
+- **Exit codes**: any refusal exits `ExitValidationError` (2, per the status-exit-codes precedent); registry unreachability exits `ExitConnectivityError` (3); success 0. No specific code is promised to sweeps (0011's constraint) — the CLI publishes one artifact per invocation.
+- **Deliberately out of scope**: refusals 9 and 11 plus `opm catalog registry check` (`cli-catalog-gates`); `version set` / `mod init` commands (`cli-authoring-commands`); `opm login` (`cli-login` — the push already reads docker config + CUE's `logins.json` through `modconfig`'s shared transport, so CI publishes work today with `docker login`); the CI cutovers; a machine-readable plan format (future, YAGNI).
+
+## Capabilities
+
+### New Capabilities
+
+- `artifact-publishing`: the identity-driven publish pipeline — gates, refusal catalog, plan/dry-run, push, exit codes.
+
+### Modified Capabilities
+
+- `mod-vet`: vet additionally reports coordinate disagreement (D16), tag/version skew (D18), and identity-package non-conformance (D21) before values validation, and becomes registry-aware (loads with the resolved registry).
+
+## Impact
+
+- **SemVer: MINOR** — new commands and a new command group; `opm module vet` gains checks (stricter output for defective modules is the feature, not a break; its flag surface is unchanged).
+- **Commands**: new `internal/cmd/catalog/` group + `publish`; new `internal/cmd/module/publish.go`; `internal/cmd/module/vet.go` modified (cfg threading + three checks).
+- **Packages**: new `internal/publish` (pipeline, gates, plan rendering), new `internal/cueedit` (the D8 writer), `internal/cmdutil`/`internal/output` additions (aligned two-column disagreement rendering — no helper exists today).
+- **New flags** (all defaulted off): `--dry-run` (repo-uniform spelling), `--version <semver>`, `--skip-override-check` (module publish only — D6's name; it waives the gate, never enables overrides). Complexity justified: each flag is named by an accepted decision's refusal action.
+- **Dependencies**: `cuelabs.dev/go/oci/ociregistry` moves indirect → direct (in-process registry tests via the public `modregistrytest`, which supports immutable tags and auth — D15/D10-shaped tests run hermetically).
+- **Consumers**: `cli-catalog-gates` extends the catalog entry point; both cutover slices point CI at these commands; `cli-authoring-commands` reuses `internal/cueedit`.
+- **Known deviations to record in 0011 on landing**: the module package-name rule gets a drafted refusal message here (none exists in 06-operational); the tidiness gate (`cue mod publish`'s `modload.CheckTidy`) is not reproduced — it is internal to the CUE module and the pipeline's full decode already refuses unresolvable dependency trees (the publishable-artifact failure class); extraneous-dep hygiene stays with `cue mod tidy` authoring flow.

--- a/openspec/changes/archive/2026-08-16-cli-publish-pipeline/specs/artifact-publishing/spec.md
+++ b/openspec/changes/archive/2026-08-16-cli-publish-pipeline/specs/artifact-publishing/spec.md
@@ -1,0 +1,89 @@
+# artifact-publishing — Delta
+
+## ADDED Requirements
+
+### Requirement: One pipeline, two entry points
+
+`opm module publish [dir]` and `opm catalog publish [dir]` SHALL share one implementation: load the artifact tree and its `identity/` subpackage, validate the identity package by unifying it against core's `#IdentityPackage` (surfacing CUE's own diagnostic — never a hand-rolled comparison), derive the registry coordinates by reading and splitting the declared `modulePath` (never composing from parts, never editing the artifact to match a coordinate), run the gates, and push via CUE's module machinery with credentials from the same resolver chain reads use. What is published SHALL be exactly the committed tree — no copied build directory, no generated files in the pushed bytes.
+
+#### Scenario: Clean artifact publishes at its declared version
+
+- **WHEN** a conformant artifact with concrete identity is published
+- **THEN** the plan prints, the push targets `<registryRepo>:v<Version>`, and the command exits 0
+
+#### Scenario: Identity is validated by unification
+
+- **WHEN** the identity package has a renamed, mistyped, or missing required field
+- **THEN** publish refuses with CUE's unification error, carrying file and line
+- **AND** no procedural expected-versus-found message is printed
+
+#### Scenario: A tree that does not load surfaces the load error
+
+- **WHEN** the artifact tree fails to load
+- **THEN** publish surfaces the load error verbatim and reports no identity-derived refusal
+
+### Requirement: Gates and refusal catalog
+
+Publish SHALL evaluate every evaluable gate, accumulate all refusals into one list, and refuse with exit code 2 when any gate fails. Each refusal SHALL follow the fixed shape condition → evidence → consequence → action, print disagreeing values in aligned columns naming the file (and line where available) that declares each, and offer a runnable command as the action. One cause SHALL yield one refusal. The gates: identity concreteness (a defaulted field counts as concrete at its default; an absent field or file is never publishable); `metadata` ↔ identity-package derivation; `cue.mod` `module:` ↔ declared path agreement (no `cue.mod` at all refuses, pointing at `opm mod init` — publish never creates or edits `cue.mod`); `source: {kind: "self"}` presence; tag equals the effective declared version and the tag major equals the path major; the module package name equals `metadata.name`; namespace and kind-segment checks on owned domains only; local-override presence; already-published tag.
+
+#### Scenario: Multiple defects reported in one pass
+
+- **WHEN** an artifact has both a coordinate disagreement and tag/version skew
+- **THEN** one invocation reports both refusals
+
+#### Scenario: Already published is always a refusal
+
+- **WHEN** the registry already holds the resolved tag
+- **THEN** publish refuses, naming the artifact, the version, and the bump command
+- **AND** no flag or mode turns this condition into a success
+
+#### Scenario: Unowned domains are not policed
+
+- **WHEN** a third-party artifact under its own domain is published
+- **THEN** no namespace or kind-segment gate refuses it
+
+### Requirement: Local overrides are never honored; modules may waive the gate
+
+Publish SHALL always resolve dependencies as published — `cue.mod/local-module.cue` replacements are ignored, never baked in. When the file is present, publish SHALL report each replacement alongside the registry version that supersedes it and refuse. `opm module publish --skip-override-check` SHALL waive the gate (not the ignoring); `opm catalog publish` SHALL have no waiver, and its check SHALL be on file presence regardless of whether replacements resolve.
+
+#### Scenario: Catalog with override always refused
+
+- **WHEN** a catalog tree carries `cue.mod/local-module.cue`
+- **THEN** publish refuses even when the flag is supplied
+
+#### Scenario: Module flag waives the gate only
+
+- **WHEN** a module tree carries the file and `--skip-override-check` is supplied
+- **THEN** publish proceeds and the published artifact resolves against published dependencies
+
+### Requirement: `--version` fills or asserts, never overwrites
+
+`--version` on either command SHALL fill an open identity `Version` (writing the working tree through the schema-fixed-path rewrite) or assert an already-concrete one; a disagreement with a concrete value SHALL refuse, naming both values and offering `version set`. An absent identity field or file SHALL NOT be fillable by the flag.
+
+#### Scenario: Fill then publish
+
+- **WHEN** the identity `Version` is open and `--version 1.3.0` is supplied
+- **THEN** the working tree's identity file is updated to `1.3.0` and the publish proceeds at `v1.3.0`
+
+#### Scenario: Assertion failure
+
+- **WHEN** the identity declares `2.4.0` and `--version 2.4.1` is supplied
+- **THEN** publish refuses printing both values and the `version set` action
+
+### Requirement: The plan is the dry run
+
+Every publish SHALL print the resolved plan — kind, declared path, `cue.mod` path, registry repository, major, tag and its source, per-field identity state, and the override-gate outcome — before any push. `--dry-run` SHALL stop after the plan, having evaluated every gate including the already-published lookup, exiting 0 on GO and 2 on REFUSED. There SHALL be no separate check mode.
+
+#### Scenario: Dry run surfaces refusals
+
+- **WHEN** `--dry-run` is supplied on a defective artifact
+- **THEN** the plan prints REFUSED with the accumulated refusal list and the command exits 2
+
+### Requirement: Exit codes
+
+Publish SHALL exit 0 on success, 2 on any refusal, 3 when a registry cannot be reached (for the core-schema fetch, the already-published lookup, or the push), and 1 on unexpected failure. No consumer contract is made on distinguishing refusal causes by code. When the already-published lookup is what failed, the plan and every locally-derived refusal SHALL still print before the connectivity error — the author's fixable problems are never hidden behind an unreachable registry, and a refusal-free plan renders an incomplete verdict rather than a GO.
+
+#### Scenario: Connectivity is not a refusal
+
+- **WHEN** the registry cannot be reached for the already-published lookup
+- **THEN** the command exits 3 and the message names the registry operation that failed

--- a/openspec/changes/archive/2026-08-16-cli-publish-pipeline/specs/mod-vet/spec.md
+++ b/openspec/changes/archive/2026-08-16-cli-publish-pipeline/specs/mod-vet/spec.md
@@ -1,0 +1,28 @@
+# mod-vet — Delta
+
+## ADDED Requirements
+
+### Requirement: Identity and coordinate checks before values validation
+
+`opm module vet` SHALL, after loading the module and before values resolution, verify: the identity package conforms to core's `#IdentityPackage` (by unification, surfacing CUE's diagnostic); `metadata.modulePath` and `metadata.version` derive from the identity package's values; and `cue.mod`'s `module:` line agrees with the declared module path. Failures SHALL report through the standard validation-error rendering with exit code 2, in the same aligned two-value form the publish refusals use, and SHALL be reported even for a module that declares no `debugValues`.
+
+#### Scenario: Coordinate drift caught at vet
+
+- **WHEN** `cue.mod` and the identity package state different module paths
+- **THEN** vet fails with both values and both files named, before any values validation
+
+#### Scenario: Replaced derivation caught at vet
+
+- **WHEN** `metadata.version` states a literal that disagrees with the identity package's `Version`
+- **THEN** vet fails naming both values and the derivation fix
+
+## MODIFIED Requirements
+
+### Requirement: Registry-aware loading
+
+Vet's module load SHALL resolve dependencies using the resolved registry (flag > env > config precedence), not the ambient process environment alone. Failing to reach the registry for the core-schema fetch SHALL exit 3 (connectivity), distinct from check failures (2).
+
+#### Scenario: Registry flag respected
+
+- **WHEN** vet runs with `--registry` pointing at a reachable mapping
+- **THEN** the module's dependencies resolve through that mapping

--- a/openspec/changes/archive/2026-08-16-cli-publish-pipeline/tasks.md
+++ b/openspec/changes/archive/2026-08-16-cli-publish-pipeline/tasks.md
@@ -1,0 +1,47 @@
+# Tasks — cli-publish-pipeline
+
+> Grouped by package, tiny chunks, every group independently green. The pipeline package builds bottom-up (states → gates → plan → push) so each layer is unit-tested before the commands exist. Commit messages: glue majors to paths (bare-`@` ban).
+
+## 1. `internal/cueedit` — the D8 writer (shared with cli-authoring-commands later)
+
+- [x] 1.1 `SetIdentityVersion(dir, version string) error`: locate `Version` in `identity/identity.cue` by the schema-fixed path, surgical AST rewrite preserving comments/field order, rebuild the file; refuse (typed error) when the file does not match `#IdentityPackage`'s shape.
+- [x] 1.2 Table tests: literal value, defaulted value (`#VersionType | *"x"` — rewrite the default), open field (insert), absent file (typed refusal), comment/alignment preservation golden.
+
+## 2. `internal/publish` — states and identity
+
+- [x] 2.1 Loader: root package + `./identity` subpackage via `load.Instances` with the resolved registry (no `os.Setenv`); load failure returns the CUE error verbatim; `cue.Value`s retained for `Pos()`.
+- [x] 2.2 Identity unification against `core.#IdentityPackage` from the kernel schema cache; CUE error surfaced through the grouped funnel (refusal 10). Test: conformant, renamed field, missing required field, absent package.
+- [x] 2.3 `IdentityState` tristate with defaults-are-concrete semantics; effective-version resolution incl. `--version` assert/fill (fill calls `cueedit`); one-cause-one-refusal on the absent path. Tests per design's state matrix.
+
+## 3. `internal/publish` — gates and plan
+
+- [x] 3.1 Derivation gates: `metadata` ↔ `id` agreement (msg 7), `cue.mod` `module:` ↔ declared path (msg 2), no-`cue.mod` (msg 3), `source: {kind:"self"}` preflight (new msg).
+- [x] 3.2 Coordinate derivation (split declared path), tag construction, tag/version + tag-major/path-major gate (msg 6), namespace/kind gates (owned domains only — pin the four passing cases from `schemas/target.cue`: vanity, testing, community, core).
+- [x] 3.3 Module package-name gate (msg 8 per design's drafted message); catalog entry point skips it.
+- [x] 3.4 Override gate: file-presence detection (reuse `pkg/loader` provenance helpers), per-replacement report lines with superseding registry versions, msgs 4a/4b, `--skip-override-check` waives the gate for modules only and changes nothing else. Tests: all four presence/flag states × both kinds + published-deps resolution assertion.
+- [x] 3.5 Refusal accumulation (all evaluable gates run; load failure short-circuits) and plan rendering per experiment 02's format; aligned two-value column helper added to `internal/output` with tests.
+
+## 4. `internal/publish` — registry I/O
+
+- [x] 4.1 Already-published lookup via `modregistry.Client.ModuleVersions` (msg 8 of the catalog — refusal 8); unreachable registry → connectivity error (exit 3), distinct from refusal. In-process `modregistrytest` tests (immutable tags).
+- [x] 4.2 Push: `modzip.CreateFromDir` → `PutModule` through `modconfig.NewResolver(&Config{CUERegistry: cfg.Registry})`; round-trip test (publish, then resolve the module back and compare identity); authenticated-push test via `modregistrytest.NewServer` + `AuthConfig`.
+
+## 5. Commands
+
+- [x] 5.1 `internal/cmd/catalog/catalog.go` (new group, registered in root.go) + `publish.go`; `internal/cmd/module/publish.go`. Thin: flags (`--version`, `--dry-run`, module-only `--skip-override-check`), delegate to `internal/publish`, exit-code mapping. Constructor tests per house pattern.
+- [x] 5.2 E2E: refusal-shape assertions modeled on `vet_output_test.go` (msg 2's aligned columns, msg 4b's flag mention, dry-run GO exit 0 / REFUSED exit 2), against fixture trees.
+
+## 6. `opm module vet` (D16/D18/D21)
+
+- [x] 6.1 Thread `cfg` into vet; loads use the resolved registry (constructor + `runVet` signature; existing tests updated).
+- [x] 6.2 Insert the three checks between module load and the values stanza, rendering as `FormatVetCheck` lines; failures through `PrintValidationError` + exit 2. Tests: coordinate drift, derivation drift, non-conformant identity, all on a module with no `debugValues`.
+
+## 7. Specs, docs, validation gates
+
+- [x] 7.1 Spec deltas: new `artifact-publishing` capability; `mod-vet` delta.
+- [x] 7.2 `CLAUDE.md` package map + command groups updated (`internal/publish`, `internal/cueedit`, `internal/cmd/catalog/`); `docs/roadmap.md`'s stale `distribution-v1`/oras-go publish paragraph corrected to this pipeline.
+- [x] 7.3 `task fmt`, `task vet`, `task lint`, `task test` — all green.
+
+## 8. Record
+
+- [x] 8.1 `enhancements/0011/`: slice → `done` + `openspec_ref` + history event, recording the three deviations (package-name refusal message drafted CLI-side; tidiness gate not reproduced — decode covers the load-failure class; `internal/cueedit` writer landed here for `cli-authoring-commands` to reuse) and the D4 evidence correction (catalog-vs-module `cue vet` asymmetry) so 03-decisions.md's stale sentence is not propagated.

--- a/openspec/specs/artifact-publishing/spec.md
+++ b/openspec/specs/artifact-publishing/spec.md
@@ -1,0 +1,93 @@
+# Capability: artifact-publishing
+
+## Purpose
+
+The identity-driven publish pipeline behind `opm module publish` and `opm catalog publish` (enhancement 0011, slice cli-publish-pipeline). Coordinates derive from the artifact's own committed identity — never composed from parts, never written back to match a coordinate — gates refuse in a fixed, actionable shape, the resolved plan doubles as the dry run, and what is published is exactly the committed tree.
+
+## Requirements
+
+### Requirement: One pipeline, two entry points
+
+`opm module publish [dir]` and `opm catalog publish [dir]` SHALL share one implementation: load the artifact tree and its `identity/` subpackage, validate the identity package by unifying it against core's `#IdentityPackage` (surfacing CUE's own diagnostic — never a hand-rolled comparison), derive the registry coordinates by reading and splitting the declared `modulePath` (never composing from parts, never editing the artifact to match a coordinate), run the gates, and push via CUE's module machinery with credentials from the same resolver chain reads use. What is published SHALL be exactly the committed tree — no copied build directory, no generated files in the pushed bytes.
+
+#### Scenario: Clean artifact publishes at its declared version
+
+- **WHEN** a conformant artifact with concrete identity is published
+- **THEN** the plan prints, the push targets `<registryRepo>:v<Version>`, and the command exits 0
+
+#### Scenario: Identity is validated by unification
+
+- **WHEN** the identity package has a renamed, mistyped, or missing required field
+- **THEN** publish refuses with CUE's unification error, carrying file and line
+- **AND** no procedural expected-versus-found message is printed
+
+#### Scenario: A tree that does not load surfaces the load error
+
+- **WHEN** the artifact tree fails to load
+- **THEN** publish surfaces the load error verbatim and reports no identity-derived refusal
+
+### Requirement: Gates and refusal catalog
+
+Publish SHALL evaluate every evaluable gate, accumulate all refusals into one list, and refuse with exit code 2 when any gate fails. Each refusal SHALL follow the fixed shape condition → evidence → consequence → action, print disagreeing values in aligned columns naming the file (and line where available) that declares each, and offer a runnable command as the action. One cause SHALL yield one refusal. The gates: identity concreteness (a defaulted field counts as concrete at its default; an absent field or file is never publishable); `metadata` ↔ identity-package derivation; `cue.mod` `module:` ↔ declared path agreement (no `cue.mod` at all refuses, pointing at `opm mod init` — publish never creates or edits `cue.mod`); `source: {kind: "self"}` presence; tag equals the effective declared version and the tag major equals the path major; the module package name equals `metadata.name`; namespace and kind-segment checks on owned domains only; local-override presence; already-published tag.
+
+#### Scenario: Multiple defects reported in one pass
+
+- **WHEN** an artifact has both a coordinate disagreement and tag/version skew
+- **THEN** one invocation reports both refusals
+
+#### Scenario: Already published is always a refusal
+
+- **WHEN** the registry already holds the resolved tag
+- **THEN** publish refuses, naming the artifact, the version, and the bump command
+- **AND** no flag or mode turns this condition into a success
+
+#### Scenario: Unowned domains are not policed
+
+- **WHEN** a third-party artifact under its own domain is published
+- **THEN** no namespace or kind-segment gate refuses it
+
+### Requirement: Local overrides are never honored; modules may waive the gate
+
+Publish SHALL always resolve dependencies as published — `cue.mod/local-module.cue` replacements are ignored, never baked in. When the file is present, publish SHALL report each replacement alongside the registry version that supersedes it and refuse. `opm module publish --skip-override-check` SHALL waive the gate (not the ignoring); `opm catalog publish` SHALL have no waiver, and its check SHALL be on file presence regardless of whether replacements resolve.
+
+#### Scenario: Catalog with override always refused
+
+- **WHEN** a catalog tree carries `cue.mod/local-module.cue`
+- **THEN** publish refuses even when the flag is supplied
+
+#### Scenario: Module flag waives the gate only
+
+- **WHEN** a module tree carries the file and `--skip-override-check` is supplied
+- **THEN** publish proceeds and the published artifact resolves against published dependencies
+
+### Requirement: `--version` fills or asserts, never overwrites
+
+`--version` on either command SHALL fill an open identity `Version` (writing the working tree through the schema-fixed-path rewrite) or assert an already-concrete one; a disagreement with a concrete value SHALL refuse, naming both values and offering `version set`. An absent identity field or file SHALL NOT be fillable by the flag.
+
+#### Scenario: Fill then publish
+
+- **WHEN** the identity `Version` is open and `--version 1.3.0` is supplied
+- **THEN** the working tree's identity file is updated to `1.3.0` and the publish proceeds at `v1.3.0`
+
+#### Scenario: Assertion failure
+
+- **WHEN** the identity declares `2.4.0` and `--version 2.4.1` is supplied
+- **THEN** publish refuses printing both values and the `version set` action
+
+### Requirement: The plan is the dry run
+
+Every publish SHALL print the resolved plan — kind, declared path, `cue.mod` path, registry repository, major, tag and its source, per-field identity state, and the override-gate outcome — before any push. `--dry-run` SHALL stop after the plan, having evaluated every gate including the already-published lookup, exiting 0 on GO and 2 on REFUSED. There SHALL be no separate check mode.
+
+#### Scenario: Dry run surfaces refusals
+
+- **WHEN** `--dry-run` is supplied on a defective artifact
+- **THEN** the plan prints REFUSED with the accumulated refusal list and the command exits 2
+
+### Requirement: Exit codes
+
+Publish SHALL exit 0 on success, 2 on any refusal, 3 when a registry cannot be reached (for the core-schema fetch, the already-published lookup, or the push), and 1 on unexpected failure. No consumer contract is made on distinguishing refusal causes by code. When the already-published lookup is what failed, the plan and every locally-derived refusal SHALL still print before the connectivity error — the author's fixable problems are never hidden behind an unreachable registry, and a refusal-free plan renders an incomplete verdict rather than a GO.
+
+#### Scenario: Connectivity is not a refusal
+
+- **WHEN** the registry cannot be reached for the already-published lookup
+- **THEN** the command exits 3 and the message names the registry operation that failed

--- a/openspec/specs/mod-vet/spec.md
+++ b/openspec/specs/mod-vet/spec.md
@@ -121,7 +121,8 @@ Flags:
 |------|---------|
 | 0 | Validation passed |
 | 1 | Usage error (invalid flags, missing arguments) |
-| 2 | Validation error (CUE errors, invalid values, missing `debugValues`) |
+| 2 | Validation error (CUE errors, invalid values, missing `debugValues`, identity/coordinate check failures) |
+| 3 | Registry unreachable (core-schema fetch) |
 
 #### Scenario: Exit code 0 on success
 
@@ -132,3 +133,26 @@ Flags:
 
 - **WHEN** `opm mod vet .` fails due to CUE errors
 - **THEN** the exit code SHALL be 2
+
+### Requirement: Identity and coordinate checks before values validation
+
+`opm module vet` SHALL, after loading the module and before values resolution, verify: the identity package conforms to core's `#IdentityPackage` (by unification, surfacing CUE's diagnostic); `metadata.modulePath` and `metadata.version` derive from the identity package's values; and `cue.mod`'s `module:` line agrees with the declared module path. Failures SHALL report through the standard validation-error rendering with exit code 2, in the same aligned two-value form the publish refusals use, and SHALL be reported even for a module that declares no `debugValues`.
+
+#### Scenario: Coordinate drift caught at vet
+
+- **WHEN** `cue.mod` and the identity package state different module paths
+- **THEN** vet fails with both values and both files named, before any values validation
+
+#### Scenario: Replaced derivation caught at vet
+
+- **WHEN** `metadata.version` states a literal that disagrees with the identity package's `Version`
+- **THEN** vet fails naming both values and the derivation fix
+
+### Requirement: Registry-aware loading
+
+Vet's module load SHALL resolve dependencies using the resolved registry (flag > env > config precedence), not the ambient process environment alone. Failing to reach the registry for the core-schema fetch SHALL exit 3 (connectivity), distinct from check failures (2).
+
+#### Scenario: Registry flag respected
+
+- **WHEN** vet runs with `--registry` pointing at a reachable mapping
+- **THEN** the module's dependencies resolve through that mapping

--- a/pkg/loader/instance_file.go
+++ b/pkg/loader/instance_file.go
@@ -72,41 +72,6 @@ func LoadInstanceFile(ctx *cue.Context, filePath string, opts LoadOptions) (cue.
 	return val, parentDir, nil
 }
 
-// LoadModulePackage loads a module CUE package from a directory and returns
-// the raw cue.Value. Used by opm module vet to load a module for validation.
-func LoadModulePackage(ctx *cue.Context, dirPath string) (cue.Value, error) {
-	absDir, err := filepath.Abs(dirPath)
-	if err != nil {
-		return cue.Value{}, fmt.Errorf("resolving module directory: %w", err)
-	}
-
-	info, err := os.Stat(absDir)
-	if err != nil {
-		return cue.Value{}, fmt.Errorf("accessing module directory %q: %w", absDir, err)
-	}
-	if !info.IsDir() {
-		return cue.Value{}, fmt.Errorf("module path %q is not a directory", absDir)
-	}
-
-	cfg := &load.Config{
-		Dir: absDir,
-	}
-	instances := load.Instances([]string{"."}, cfg)
-	if len(instances) == 0 {
-		return cue.Value{}, fmt.Errorf("no CUE instances found in %s", absDir)
-	}
-	if instances[0].Err != nil {
-		return cue.Value{}, fmt.Errorf("loading module package from %s: %w", absDir, instances[0].Err)
-	}
-
-	val := ctx.BuildInstance(instances[0])
-	if err := val.Err(); err != nil {
-		return cue.Value{}, fmt.Errorf("building module package from %s: %w", absDir, err)
-	}
-
-	return val, nil
-}
-
 // LoadValuesFile loads a standalone CUE values file and returns the concrete
 // values as a cue.Value. The function first tries to extract a "values" field
 // from the loaded file (the standard OPM values file shape); if no such field

--- a/pkg/loader/instance_file_test.go
+++ b/pkg/loader/instance_file_test.go
@@ -29,30 +29,6 @@ language: version: "v0.15.0"
 	return filePath
 }
 
-// makeModuleFixture creates a temp module directory with a minimal CUE package.
-func makeModuleFixture(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-
-	modDir := filepath.Join(dir, "cue.mod")
-	require.NoError(t, os.MkdirAll(modDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(modDir, "module.cue"), []byte(`module: "example.com/mymodule@v0"
-language: version: "v0.15.0"
-`), 0o644))
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "module.cue"), []byte(`package mymodule
-
-metadata: {
-	name:    "my-module"
-	version: "0.1.0"
-}
-#config: {
-	replicas: *1 | int
-}
-`), 0o644))
-	return dir
-}
-
 // TestLoadInstanceFile tests loading standalone .cue instance files.
 func TestLoadInstanceFile(t *testing.T) {
 	ctx := cuecontext.New()
@@ -94,38 +70,5 @@ kind: "ModuleInstance"
 		_, dir, err := LoadInstanceFile(ctx, filePath, LoadOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, filepath.Dir(filePath), dir)
-	})
-}
-
-// TestLoadModulePackage tests loading a module CUE package from a directory.
-func TestLoadModulePackage(t *testing.T) {
-	ctx := cuecontext.New()
-
-	t.Run("valid module directory", func(t *testing.T) {
-		dir := makeModuleFixture(t)
-		val, err := LoadModulePackage(ctx, dir)
-		require.NoError(t, err)
-		assert.NoError(t, val.Err())
-
-		// The module should have a metadata field.
-		name, nameErr := val.LookupPath(cue.ParsePath("metadata.name")).String()
-		require.NoError(t, nameErr)
-		assert.Equal(t, "my-module", name)
-	})
-
-	t.Run("missing directory", func(t *testing.T) {
-		_, err := LoadModulePackage(ctx, "/nonexistent/module/dir")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "accessing module directory")
-	})
-
-	t.Run("path is a file not directory", func(t *testing.T) {
-		dir := t.TempDir()
-		filePath := filepath.Join(dir, "somefile.cue")
-		require.NoError(t, os.WriteFile(filePath, []byte(`kind: "x"`), 0o644))
-
-		_, err := LoadModulePackage(ctx, filePath)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not a directory")
 	})
 }

--- a/tests/e2e/publish_test.go
+++ b/tests/e2e/publish_test.go
@@ -1,0 +1,163 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"cuelabs.dev/go/oci/ociregistry/ocimem"
+	"cuelang.org/go/mod/modregistrytest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// publishModuleFixture writes a minimal, import-free module tree that
+// conforms to core's #IdentityPackage, mutated per test.
+func publishModuleFixture(t *testing.T, mutate func(map[string]string)) string {
+	t.Helper()
+	files := map[string]string{
+		"cue.mod/module.cue": `module: "example.com/modules/demo@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+`,
+		"identity/identity.cue": `package identity
+
+ModulePath: "example.com/modules/demo@v1"
+Version:    "1.2.0"
+`,
+		"module.cue": `package demo
+
+metadata: {
+	name:       "demo"
+	modulePath: "example.com/modules/demo@v1"
+	version:    "1.2.0"
+}
+`,
+	}
+	if mutate != nil {
+		mutate(files)
+	}
+	dir := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+	return dir
+}
+
+// publishRegistryEnv starts an in-process registry for the fixture domain and
+// returns the OPM_REGISTRY value routing example.com at it while the core
+// schema still resolves from GHCR.
+func publishRegistryEnv(t *testing.T) string {
+	t.Helper()
+	reg, err := modregistrytest.NewServer(ocimem.NewWithConfig(&ocimem.Config{ImmutableTags: true}), nil)
+	require.NoError(t, err)
+	t.Cleanup(reg.Close)
+	return "OPM_REGISTRY=opmodel.dev=ghcr.io/open-platform-model,example.com=" + reg.Host() + "+insecure,registry.cue.works"
+}
+
+// runOPMPublish runs the opm binary with extra environment entries, capturing
+// stdout and stderr independently regardless of exit status.
+func runOPMPublish(t *testing.T, workDir string, extraEnv []string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, opmBinary, args...)
+	cmd.Dir = workDir
+	cmd.Env = append(append(os.Environ(), "HOME="+homeDir), extraEnv...)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err = cmd.Run()
+	return stdoutBuf.String(), stderrBuf.String(), err
+}
+
+// skipWithoutCoreSchema skips when the core v2 schema cannot be resolved
+// (offline, no warm cache) — matching the repo's other registry-backed tests.
+func skipWithoutCoreSchema(t *testing.T, stderr string) {
+	t.Helper()
+	if strings.Contains(stderr, "loading core schema") {
+		t.Skipf("core v2 schema unavailable (registry/cache): %s", stderr)
+	}
+}
+
+func TestE2E_ModulePublish_DryRunGO(t *testing.T) {
+	dir := publishModuleFixture(t, nil)
+	env := []string{publishRegistryEnv(t)}
+
+	stdout, stderr, err := runOPMPublish(t, dir, env, "module", "publish", "--dry-run")
+	skipWithoutCoreSchema(t, stderr)
+	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+
+	// The plan is the dry run: every coordinate derived from the artifact.
+	assert.Contains(t, stdout, "declaredPath    example.com/modules/demo@v1")
+	assert.Contains(t, stdout, "registryRepo    example.com/modules/demo")
+	assert.Contains(t, stdout, "tag             v1.2.0")
+	assert.Contains(t, stdout, "GO — pushing example.com/modules/demo:v1.2.0")
+}
+
+func TestE2E_ModulePublish_DryRunRefused(t *testing.T) {
+	dir := publishModuleFixture(t, func(files map[string]string) {
+		// Two defects in one tree: cue.mod disagrees with identity (msg 2)
+		// and a local override is present (msg 4b). One invocation must
+		// report both.
+		files["cue.mod/module.cue"] = `module: "example.com/modules/other@v1"
+language: version: "v0.17.0"
+source: kind: "self"
+deps: "example.com/dep@v1": v: "v1.4.0"
+`
+		files["cue.mod/local-module.cue"] = `deps: "example.com/dep@v1": replaceWith: "../dep"
+`
+	})
+	env := []string{publishRegistryEnv(t)}
+
+	stdout, stderr, err := runOPMPublish(t, dir, env, "module", "publish", "--dry-run")
+	skipWithoutCoreSchema(t, stderr)
+
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(err, &exitErr))
+	assert.Equal(t, 2, exitErr.ExitCode(), "stdout: %s\nstderr: %s", stdout, stderr)
+
+	assert.Contains(t, stdout, "REFUSED — 2 refusals")
+
+	// Msg 2's aligned two-value columns: both paths, both declaring files.
+	assert.Contains(t, stderr, "disagrees with itself about where it lives")
+	assert.Contains(t, stderr, "declared  example.com/modules/demo@v1   identity/identity.cue:")
+	assert.Contains(t, stderr, "cue.mod   example.com/modules/other@v1  cue.mod/module.cue:")
+
+	// Msg 4b names the waiver flag and the superseding registry version.
+	assert.Contains(t, stderr, "local-module.cue is present")
+	assert.Contains(t, stderr, "--skip-override-check")
+	assert.Contains(t, stderr, "would resolve to v1.4.0 when published")
+}
+
+func TestE2E_ModulePublish_PushAndAlreadyPublished(t *testing.T) {
+	dir := publishModuleFixture(t, nil)
+	env := []string{publishRegistryEnv(t)}
+
+	// First publish pushes for real (to the in-process registry).
+	stdout, stderr, err := runOPMPublish(t, dir, env, "module", "publish")
+	skipWithoutCoreSchema(t, stderr)
+	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+
+	// Second publish refuses: a published tag names fixed bytes permanently.
+	stdout, stderr, err = runOPMPublish(t, dir, env, "module", "publish")
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(err, &exitErr))
+	assert.Equal(t, 2, exitErr.ExitCode(), "stdout: %s\nstderr: %s", stdout, stderr)
+	assert.Contains(t, stderr, "already holds v1.2.0")
+	assert.Contains(t, stderr, "opm module version set 1.2.1")
+}

--- a/tests/e2e/testdata/vet-errors/module/identity/identity.cue
+++ b/tests/e2e/testdata/vet-errors/module/identity/identity.cue
@@ -1,0 +1,6 @@
+// Package identity is the single source of this module's path and version
+// (core #IdentityPackage, enhancements 0010 D38 / 0011 D12).
+package identity
+
+ModulePath: "test.example.com/demo@v0"
+Version:    "0.1.0"

--- a/tests/e2e/testdata/vet-errors/module/module.cue
+++ b/tests/e2e/testdata/vet-errors/module/module.cue
@@ -1,9 +1,9 @@
 package demo
 
 metadata: {
-	name: "demo"
-	modulePath: "test.example.com/demo"
-	version: "0.1.0"
+	name:       "demo"
+	modulePath: "test.example.com/demo@v0"
+	version:    "0.1.0"
 }
 
 #config: {

--- a/tests/fixtures/valid/simple-module/identity/identity.cue
+++ b/tests/fixtures/valid/simple-module/identity/identity.cue
@@ -1,0 +1,6 @@
+// Package identity is the single source of this module's path and version
+// (core #IdentityPackage, enhancements 0010 D38 / 0011 D12).
+package identity
+
+ModulePath: "example.com/modules/simple_module@v0"
+Version:    "0.1.0"


### PR DESCRIPTION
Implements enhancement 0011's `cli-publish-pipeline` slice (decisions D1, D2, D4, D6, D12, D15, D16, D18, D21): one identity-driven publish pipeline with two entry points, plus the shared checks in `opm module vet`.

## What

- **New command group `opm catalog`** with `catalog publish`, and new `opm module publish` — thin cobra wrappers over one new `internal/publish` package.
- **The pipeline**: load the tree and its `identity/` subpackage with the resolved registry (no `os.Setenv`); unify identity against core's shipped `#IdentityPackage` (CUE produces the diagnostic — refusal 10); derive repo/major/tag by splitting the declared `metadata.modulePath`; run the gates; push via `modzip` → `modregistry` through `modconfig`'s resolver, so push and pull share one credential chain.
- **Refusals 1–8 and 10** in the fixed condition → evidence → consequence → action shape, aligned two-value columns naming each declaring file, actions as runnable commands. All evaluable gates run and refusals accumulate — one pass fixes everything.
- **The plan is the dry run**: every invocation prints the resolved plan; `--dry-run` stops after it with every gate evaluated, already-published lookup included. A refusal-free plan whose lookup never completed renders `INCOMPLETE`, never a false `GO`, and locally-derived refusals always print even when the registry is unreachable.
- **`--version` fills or asserts, never overwrites** — the fill writes the working tree atomically through the new `internal/cueedit` surgical rewriter (D8's schema-fixed-path `Version` write, which `cli-authoring-commands` will reuse for `version set`).
- **`opm module vet`** gains the D16/D18/D21 checks between module load and the values stanza, and its loads now use the resolved registry (flag > env > config).
- **Exit codes**: refusals 2, registry unreachable 3 (schema fetch, lookup, or push), unexpected 1.

## Tests

- Hermetic unit suites against the public `modregistrytest` (immutable tags): full gate matrix, push round-trip, authenticated push via the Docker-config credential chain, override-never-baked-in, connectivity-vs-refusal separation.
- E2E against the real GHCR-resolved core schema: dry-run GO exit 0, multi-refusal REFUSED exit 2 with aligned columns and the `--skip-override-check` mention, publish-then-already-published.
- `task fmt` / `task vet` / `task lint` / `task test` all green.

## Records

- OpenSpec change `cli-publish-pipeline` archived with specs synced (`artifact-publishing` created, `mod-vet` extended).
- `enhancements/0011`: slice → done with the three recorded deviations (CLI-drafted package-name refusal, tidiness gate not reproduced, `internal/cueedit` landing here) and the D4 evidence correction.
- `cuelabs.dev/go/oci/ociregistry` moves indirect → direct, as the proposal predicted.
