### PR TITLE
feat(fixtures): move podinfo to testing.opmodel.dev and publish it to GHCR

### DIFF
--- a/.github/scripts/publish-fixtures.sh
+++ b/.github/scripts/publish-fixtures.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Publish the repo's own test-fixture modules through `opm module publish` —
+# the same pipeline, and the same gates, the official templates go through
+# (publish-templates.sh). A fixture that violates a publish gate fails CI.
+#
+# Fixtures live on the testing domain (testing.opmodel.dev/modules/cli/*) and
+# are published to GHCR, so every consumer — examples, e2e testdata, the kind
+# dev cluster, a fresh clone — resolves them from a public registry with no
+# local registry involved.
+#
+# For each tests/fixtures/modules/*/ tree carrying an identity package: read the
+# declared coordinate from that package (grep-free — cue eval), check tag
+# existence against GHCR, and invoke publish only for unpublished versions. The
+# skip lives HERE, in the caller, because publish itself never skips: an already
+# published tag is always a refusal (D15) — idempotency is the caller-side
+# filter.
+#
+# With --dry-run (PR CI): run every gate without pushing. A dry run whose only
+# refusal is already-published still passes — on a PR the committed version may
+# legitimately be live; every other gate refusal fails the check.
+set -euo pipefail
+
+mode=publish
+if [ "${1:-}" = "--dry-run" ]; then
+  mode=dry-run
+fi
+
+opm=${OPM_BIN:-./bin/opm}
+# Both domains must map: the fixtures are on testing.opmodel.dev, their deps
+# (core, catalogs) on opmodel.dev.
+#
+# BOTH variables are required and they are read by different things. `cue eval`
+# below reads CUE_REGISTRY; `opm` does NOT — it resolves --registry > OPM_REGISTRY
+# > ~/.opm/config.cue (internal/config/resolver.go) and never looks at
+# CUE_REGISTRY. Exporting only CUE_REGISTRY silently leaves opm on the caller's
+# personal config, which reads as a clean GO against the wrong registry.
+export CUE_REGISTRY=${CUE_REGISTRY:-testing.opmodel.dev=ghcr.io/open-platform-model,opmodel.dev=ghcr.io/open-platform-model,registry.cue.works}
+export OPM_REGISTRY=${OPM_REGISTRY:-$CUE_REGISTRY}
+
+# published <repo> <tag> — 0 when the manifest exists. GHCR_AUTH
+# ("user:token") authenticates the token exchange; without it the anonymous
+# pull token serves public packages. A 404 is the normal first-publish state.
+published() {
+  local repo=$1 tag=$2 token code
+  token=$(curl -sf ${GHCR_AUTH:+-u "$GHCR_AUTH"} \
+    "https://ghcr.io/token?scope=repository:${repo}:pull" | jq -r .token) || return 1
+  code=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+    "https://ghcr.io/v2/${repo}/manifests/${tag}")
+  [ "$code" = "200" ]
+}
+
+found=0
+for dir in tests/fixtures/modules/*/; do
+  [ -d "${dir}identity" ] || continue
+  found=$((found + 1))
+  f=$(basename "$dir")
+
+  version=$(cd "$dir" && cue eval ./identity --out text -e Version)
+  tag="v${version}"
+  # Derive the GHCR repository from the declared path, not the directory name —
+  # the two need not agree, and the path is the coordinate that is published.
+  path=$(cd "$dir" && cue eval ./identity --out text -e ModulePath)
+  repo="open-platform-model/${path%@*}"
+
+  if [ "$mode" = publish ]; then
+    if published "$repo" "$tag"; then
+      echo "==> ${f}: ${tag} already published — skipped by the caller-side filter (D15)"
+      continue
+    fi
+    echo "==> ${f}: publishing ${tag} to ${repo}"
+    "$opm" module publish "./${dir}"
+  else
+    echo "==> ${f}: dry-run at ${tag} (${repo})"
+    if out=$("$opm" module publish --dry-run "./${dir}" 2>&1); then
+      echo "${out}"
+      continue
+    fi
+    echo "${out}"
+    if echo "${out}" | grep -q "already holds" && echo "${out}" | grep -q "1 refusal"; then
+      echo "==> ${f}: only refusal is already-published — acceptable on a PR"
+      continue
+    fi
+    echo "==> ${f}: publish gates refused"
+    exit 1
+  fi
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "no publishable fixture trees found under tests/fixtures/modules/" >&2
+  exit 1
+fi

--- a/.github/scripts/publish-templates.sh
+++ b/.github/scripts/publish-templates.sh
@@ -20,7 +20,12 @@ if [ "${1:-}" = "--dry-run" ]; then
 fi
 
 opm=${OPM_BIN:-./bin/opm}
+# BOTH are required: `cue eval` reads CUE_REGISTRY, `opm` reads OPM_REGISTRY
+# (--registry > OPM_REGISTRY > ~/.opm/config.cue — never CUE_REGISTRY). With only
+# CUE_REGISTRY set, opm silently falls through to the caller's personal config;
+# it happens to work on a CI runner that has none, and misleads everywhere else.
 export CUE_REGISTRY=${CUE_REGISTRY:-opmodel.dev=ghcr.io/open-platform-model}
+export OPM_REGISTRY=${OPM_REGISTRY:-$CUE_REGISTRY}
 
 # published <repo> <tag> — 0 when the manifest exists. GHCR_AUTH
 # ("user:token") authenticates the token exchange; without it the anonymous

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,9 +15,11 @@ concurrency:
 env:
   # GHCR mapping: no registry service runs in CI, so anything the tests
   # genuinely resolve must be published (public) on GHCR — same arrangement as
-  # the library repo's CI.
-  OPM_REGISTRY: 'opmodel.dev=ghcr.io/open-platform-model,registry.cue.works'
-  CUE_REGISTRY: 'opmodel.dev=ghcr.io/open-platform-model,registry.cue.works'
+  # the library repo's CI. testing.opmodel.dev carries this repo's fixture
+  # modules, published by publish-fixtures.yml; it is a GHCR-backed domain like
+  # any other, not a local-registry alias.
+  OPM_REGISTRY: 'testing.opmodel.dev=ghcr.io/open-platform-model,opmodel.dev=ghcr.io/open-platform-model,registry.cue.works'
+  CUE_REGISTRY: 'testing.opmodel.dev=ghcr.io/open-platform-model,opmodel.dev=ghcr.io/open-platform-model,registry.cue.works'
 
 jobs:
   lint:
@@ -62,6 +64,24 @@ jobs:
         run: go install cuelang.org/go/cmd/cue@v0.17.1
       - name: Dry-run the template publish gates
         run: .github/scripts/publish-templates.sh --dry-run
+
+  fixture-gates:
+    # The same gates over the fixture trees, dry-run. A fixture that would fail
+    # publish-fixtures.yml fails the PR first, rather than after merge when the
+    # publish workflow is the only thing that would have caught it.
+    name: Fixture Publish Gates (dry-run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.0'
+      - name: Build opm
+        run: go build -o bin/opm ./cmd/opm
+      - name: Install cue
+        run: go install cuelang.org/go/cmd/cue@v0.17.1
+      - name: Dry-run the fixture publish gates
+        run: .github/scripts/publish-fixtures.sh --dry-run
 
   integration:
     name: Integration Tests

--- a/.github/workflows/publish-fixtures.yml
+++ b/.github/workflows/publish-fixtures.yml
@@ -1,0 +1,56 @@
+name: Publish Fixtures
+
+# The repo's own test-fixture modules live on the testing domain
+# (testing.opmodel.dev/modules/cli/*) and are published to GHCR, so consumers —
+# examples, e2e testdata, the kind dev cluster, a fresh clone — resolve them
+# from a public registry with no local registry involved.
+#
+# Independent of the cli's release train: a fixture is not release-please
+# managed, and a fixture bump should reach the registry without waiting for a
+# release. The script's caller-side GHCR probe makes re-runs no-ops, so pushing
+# an unrelated change under tests/fixtures/modules/ publishes nothing.
+#
+# workflow_dispatch is the bootstrap and repair path: dispatch against a branch
+# to publish a new coordinate BEFORE the consumers that pin it merge.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tests/fixtures/modules/**'
+      - '.github/scripts/publish-fixtures.sh'
+      - '.github/workflows/publish-fixtures.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish fixture modules
+    # Forks have no access to GITHUB_TOKEN with packages:write — skip cleanly.
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.0'
+
+      - name: Build opm
+        run: go build -o bin/opm ./cmd/opm
+
+      - name: Install cue
+        run: go install cuelang.org/go/cmd/cue@v0.17.1
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Publish unpublished fixtures
+        run: .github/scripts/publish-fixtures.sh
+        env:
+          GHCR_AUTH: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,14 +111,15 @@ Read when entering `cli/`:
   fixtures pin `opmodel.dev/core` `v2.0.0-alpha.4` and `opmodel.dev/catalogs/opm`
   `v2.0.0-alpha.3`; the seeded platform template pins the same catalog build
   (mirror peers: `hack/platform.cue`, the operator's sample Platform).
-- Integration + CUE workflows need registry config. Follow the Registry Policy in the root `CLAUDE.md` — reads resolve `opmodel.dev/*` from GHCR:
+- Integration + CUE workflows need registry config. Follow the Registry Policy in the root `CLAUDE.md` — both `opmodel.dev/*` and `testing.opmodel.dev/*` resolve from GHCR:
 
 ```bash
-export CUE_REGISTRY='opmodel.dev=ghcr.io/open-platform-model,testing.opmodel.dev=localhost:5000+insecure,registry.cue.works'
+export CUE_REGISTRY='opmodel.dev=ghcr.io/open-platform-model,testing.opmodel.dev=ghcr.io/open-platform-model,registry.cue.works'
 export OPM_REGISTRY="$CUE_REGISTRY"
 ```
 
-- **Known deviation — kind dev-cluster flow:** `task cluster:operator` (and `hack/opm-config.cue`, `KIND_CUE_REGISTRY`) runs entirely against the local registry: it hard-requires the `opm-registry` container and routes `opmodel.dev/*` to it, because the loop iterates on locally published workspace modules and `opmodel.dev/modules/test/*` fixtures that are not on GHCR. Local-registry-gated — only run when the user asks for the kind dev flow. The shipped CLI default (`internal/config/templates.go`) is GHCR.
+- **No local registry is required anywhere in this repo** — unit tests, e2e, integration, the examples, and the kind dev-cluster flow all resolve from GHCR. `task cluster:operator` installs the pinned operator and relies on its built-in `--registry` default (which routes both domains to GHCR); it patches `--registry` onto the Deployment and requires the `opm-registry` container **only** when `KIND_CUE_REGISTRY` is explicitly set, which is the opt-in path for iterating against a locally published module. The shipped CLI default (`internal/config/templates.go`) matches.
+- **Test fixtures live on the testing domain.** `tests/fixtures/modules/*` declare `testing.opmodel.dev/modules/cli/<name>@v0`, carry an `identity/` package, and are published to GHCR by `.github/workflows/publish-fixtures.yml` through `opm module publish` — the same pipeline and gates the official templates go through. Never give a fixture an `opmodel.dev/*` path: CUE routes by longest prefix, so a fixture there drags core and the catalogs onto whatever registry serves the fixture. A fixture version bump is an edit to `identity/identity.cue` plus a re-pin in every consumer; publish it (dispatch the workflow) before the consumers that pin it merge.
 
 ## Build And Dev Commands
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,19 +9,28 @@ vars:
   CLUSTER_NAME: opm-dev
   K8S_NODE_IMAGE: "kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48"
   REGISTRY_CONTAINER: '{{.REGISTRY_CONTAINER | default "opm-registry"}}'
-  # Canonical mapping (Registry Policy, root CLAUDE.md): opmodel.dev/* reads
-  # resolve from GHCR; testing.opmodel.dev/* from the local registry. An
-  # exported OPM_REGISTRY wins. The kind dev-cluster flow (cluster:operator)
-  # uses its own local mappings — see KIND_CUE_REGISTRY and hack/opm-config.cue.
+  # Canonical mapping (Registry Policy, root CLAUDE.md): both opmodel.dev/* and
+  # testing.opmodel.dev/* read from GHCR. The testing domain carries this repo's
+  # fixture modules, published by .github/workflows/publish-fixtures.yml — it is
+  # a GHCR-backed domain, not a local-registry alias. An exported OPM_REGISTRY
+  # wins.
   OPM_REGISTRY:
-    sh: echo "${OPM_REGISTRY:-opmodel.dev=ghcr.io/open-platform-model,testing.opmodel.dev=localhost:5000+insecure,registry.cue.works}"
-  # The in-cluster spelling of OPM_REGISTRY. The host reaches the registry on
-  # localhost:5000 (published port); a pod reaches the same container by its
-  # name on kind's docker network. Same blobs, two addresses — module identity
-  # (opmodel.dev/...) is stable across both, only the host part differs.
-  # Both opmodel.dev AND testing.opmodel.dev must map, or publishes/pulls fall
-  # through to a remote host and 401.
-  KIND_CUE_REGISTRY: '{{.KIND_CUE_REGISTRY | default "opmodel.dev=opm-registry:5000+insecure,testing.opmodel.dev=opm-registry:5000+insecure,registry.cue.works"}}'
+    sh: echo "${OPM_REGISTRY:-testing.opmodel.dev=ghcr.io/open-platform-model,opmodel.dev=ghcr.io/open-platform-model,registry.cue.works}"
+  # Opt-in override for the kind dev cluster, EMPTY by default. Nothing the kind
+  # flow resolves is local-only any more, so the operator's own built-in default
+  # (which routes both domains to GHCR) is correct out of the box and
+  # cluster:operator needs no local registry at all.
+  #
+  # Set this only to iterate on a module you have published locally, e.g.
+  #
+  #   task cluster:operator \
+  #     KIND_CUE_REGISTRY='testing.opmodel.dev=opm-registry:5000+insecure,opmodel.dev=ghcr.io/open-platform-model,registry.cue.works'
+  #
+  # Use the IN-CLUSTER spelling: the host reaches the registry on localhost:5000
+  # (published port), but a pod reaches the same container by its name on kind's
+  # docker network. Same blobs, two addresses — module identity is stable across
+  # both, only the host part differs.
+  KIND_CUE_REGISTRY: '{{.KIND_CUE_REGISTRY | default ""}}'
   VERSION:
     sh: git describe --tags --always --dirty 2>/dev/null || echo "v0.0.0-dev"
   COMMIT:
@@ -179,44 +188,58 @@ tasks:
       - task: cluster:create
 
   cluster:operator:
-    desc: Install a reconciling operator into the kind cluster, wired to the local registry
+    desc: Install a reconciling operator into the kind cluster
     summary: |
-      Brings up an opm-operator that can actually reconcile ModuleInstances
-      against the local OCI registry, which the handoff/adoption e2e tests
-      require.
+      Brings up an opm-operator that can actually reconcile ModuleInstances,
+      which the handoff/adoption e2e tests require.
 
-      Three things have to be true and none of them are the default:
+      By default this needs no local registry. Everything the kind flow
+      resolves — core, the catalogs, and this repo's own
+      testing.opmodel.dev/modules/cli/* fixtures — is published on GHCR, and the
+      operator's built-in --registry default already routes both domains there.
 
-        1. The registry container must be on kind's docker network, so the
-           operator pod can reach it by name.
-        2. The operator must be told to use it. Its registry is a COMMAND-LINE
-           FLAG, not an env var: --registry wins over OPM_REGISTRY (which is
-           only read when the flag is empty, and the flag defaults to GHCR),
-           and the operator overwrites CUE_REGISTRY in its own process env.
-           Setting either as a pod env var does nothing.
-        3. A cluster Platform singleton named "cluster" must exist, or every
+      Two things still have to be true and neither is automatic:
+
+        1. A cluster Platform singleton named "cluster" must exist, or every
            ModuleInstance parks at Ready=False/PlatformNotReady.
+        2. The operator ships with no workload permissions — it expects to
+           impersonate a per-instance ServiceAccount the CLI cannot write.
 
-      Idempotent: safe to re-run. Requires the registry container from
-      `task registry:start` at the workspace root (.tasks/registry/docker.yml),
-      or any registry named {{.REGISTRY_CONTAINER}} publishing :5000. This is a
-      local-registry-gated dev flow (Registry Policy, root CLAUDE.md): the
-      whole kind loop runs against the local registry by design.
+      To iterate against a module published to your LOCAL registry, set
+      KIND_CUE_REGISTRY (see the var's comment for the in-cluster spelling).
+      That path additionally requires the registry container from
+      `task registry:start` at the workspace root, joins it to kind's docker
+      network, and patches --registry onto the operator Deployment. The
+      operator's registry is a COMMAND-LINE FLAG, not an env var: --registry
+      wins over OPM_REGISTRY (which is only read when the flag is empty), and
+      the operator overwrites CUE_REGISTRY in its own process env. Setting
+      either as a pod env var does nothing.
+
+      Idempotent: safe to re-run.
     preconditions:
       - sh: kubectl cluster-info --context kind-{{.CLUSTER_NAME}} &>/dev/null
         msg: "Cluster 'kind-{{.CLUSTER_NAME}}' is not running. Run: task cluster:create"
-      - sh: docker ps -f name={{.REGISTRY_CONTAINER}} --format '{{`{{.Names}}`}}' | grep -qx {{.REGISTRY_CONTAINER}}
-        msg: "Registry container '{{.REGISTRY_CONTAINER}}' is not running — the operator has nowhere to resolve modules from."
     cmds:
-      # The kind network only exists once a cluster has been created, so this
-      # cannot move into cluster:create. Errors when already connected.
-      - docker network connect kind {{.REGISTRY_CONTAINER}} 2>/dev/null || true
       # --config keeps this hermetic: the dev-cluster tooling must not depend on
       # a developer's personal ~/.opm being present or in the post-D39 format.
       - ./{{.BUILD_DIR}}/{{.BINARY_NAME}} operator install --config hack/opm-config.cue --context kind-{{.CLUSTER_NAME}} --timeout 180s
-      # Append --registry only if it is not already there, so re-runs do not
-      # stack duplicate flags on the container args.
+      # Local-registry opt-in. No-op unless KIND_CUE_REGISTRY is set; append
+      # --registry only if it is not already there, so re-runs do not stack
+      # duplicate flags on the container args.
       - |
+        registry='{{.KIND_CUE_REGISTRY}}'
+        if [ -z "$registry" ]; then
+          echo "using the operator's built-in registry default (GHCR); set KIND_CUE_REGISTRY to override"
+          exit 0
+        fi
+        if ! docker ps -f name={{.REGISTRY_CONTAINER}} --format '{{`{{.Names}}`}}' | grep -qx {{.REGISTRY_CONTAINER}}; then
+          echo "KIND_CUE_REGISTRY is set but registry container '{{.REGISTRY_CONTAINER}}' is not running." >&2
+          echo "Run 'task registry:start' at the workspace root, or unset KIND_CUE_REGISTRY to use GHCR." >&2
+          exit 1
+        fi
+        # The kind network only exists once a cluster has been created, so this
+        # cannot move into cluster:create. Errors when already connected.
+        docker network connect kind {{.REGISTRY_CONTAINER}} 2>/dev/null || true
         current=$(kubectl --context kind-{{.CLUSTER_NAME}} -n opm-operator-system get deployment opm-operator-controller-manager \
           -o jsonpath='{.spec.template.spec.containers[0].args}')
         if echo "$current" | grep -q -- "--registry="; then
@@ -224,7 +247,7 @@ tasks:
         else
           kubectl --context kind-{{.CLUSTER_NAME}} -n opm-operator-system patch deployment opm-operator-controller-manager \
             --type=json \
-            -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--registry={{.KIND_CUE_REGISTRY}}"}]'
+            -p "[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/args/-\",\"value\":\"--registry=${registry}\"}]"
         fi
       - kubectl --context kind-{{.CLUSTER_NAME}} -n opm-operator-system rollout status deployment/opm-operator-controller-manager --timeout=180s
       - kubectl --context kind-{{.CLUSTER_NAME}} apply -f hack/kind-platform.yaml
@@ -243,8 +266,8 @@ tasks:
         done
         echo "Platform/cluster has no status.operatorVersion after 120s." >&2
         echo "Check: kubectl -n opm-operator-system logs deploy/opm-operator-controller-manager" >&2
-        echo "A 'Failed to resolve OPM core schema' line means the --registry patch did not take" >&2
-        echo "or the registry is unreachable from inside the pod." >&2
+        echo "A 'Failed to resolve OPM core schema' line means the pod cannot reach the registry" >&2
+        echo "its --registry flag (or built-in default) points at." >&2
         exit 1
 
   cluster:operator:status:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,15 +1,17 @@
 # Examples
 
-Deployable `#ModuleInstance` examples on the OPM v2 line, importing the
-neutral `opmodel.dev/modules/test/*` fixture modules.
+Deployable `#ModuleInstance` examples on the OPM v2 line, importing this
+repo's own `testing.opmodel.dev/modules/cli/*` fixture modules. Those are
+published to GHCR by `.github/workflows/publish-fixtures.yml`, so the examples
+build against a public registry — no local registry, no sibling checkout.
 
 - `instances/podinfo/` — Deployment + Service with HTTP liveness/readiness
-  probes (`opmodel.dev/modules/test/podinfo@v0`).
+  probes (`testing.opmodel.dev/modules/cli/podinfo@v0`).
 
 The former `hello-web` example was removed at the core v2 crossing: its
 hyphenated module name cannot exist on the v2 line (module names are
-snake_case and equal the module path leaf). The fixture fleet republishes it
-as `hello_web`; a new example importing
+snake_case and equal the module path leaf). The operator's fixture fleet
+republishes it as `hello_web`; a new example importing
 `opmodel.dev/modules/test/hello_web@v0` can be added once needed.
 
 Build:   `opm instance build ./instances/podinfo/instance.cue`

--- a/examples/Taskfile.yml
+++ b/examples/Taskfile.yml
@@ -3,11 +3,10 @@ version: "3"
 silent: true
 
 env:
-  # Known deviation (Registry Policy, root CLAUDE.md): the example modules pin
-  # opmodel.dev/modules/test/* fixtures that exist only in the local registry,
-  # so that prefix routes to localhost until the fixtures move under
-  # testing.opmodel.dev/*. Everything else (core, catalogs) resolves from GHCR.
-  CUE_REGISTRY: "opmodel.dev/modules/test=localhost:5000+insecure,testing.opmodel.dev=localhost:5000+insecure,opmodel.dev=ghcr.io/open-platform-model,registry.cue.works"
+  # Everything these examples resolve is on GHCR: core and the catalogs under
+  # opmodel.dev, this repo's fixture modules under testing.opmodel.dev
+  # (published by .github/workflows/publish-fixtures.yml). No local registry.
+  CUE_REGISTRY: "testing.opmodel.dev=ghcr.io/open-platform-model,opmodel.dev=ghcr.io/open-platform-model,registry.cue.works"
 
 tasks:
   deps:update:

--- a/examples/cue.mod/module.cue
+++ b/examples/cue.mod/module.cue
@@ -12,7 +12,7 @@ deps: {
 	"opmodel.dev/core@v2": {
 		v: "v2.0.0-alpha.4"
 	}
-	"opmodel.dev/modules/test/podinfo@v0": {
+	"testing.opmodel.dev/modules/cli/podinfo@v0": {
 		v: "v0.1.4"
 	}
 }

--- a/examples/instances/podinfo/instance.cue
+++ b/examples/instances/podinfo/instance.cue
@@ -1,6 +1,6 @@
 // podinfo instance example (opmodel.dev/core@v2).
 // Imports the neutral podinfo test module
-// (opmodel.dev/modules/test/podinfo@v0) and binds it to a #ModuleInstance.
+// (testing.opmodel.dev/modules/cli/podinfo@v0) and binds it to a #ModuleInstance.
 // Renders a Deployment + Service with HTTP liveness/readiness probes.
 //
 // Build:   opm instance build ./examples/instances/podinfo/instance.cue
@@ -9,7 +9,7 @@ package podinfo
 
 import (
 	core "opmodel.dev/core@v2"
-	podinfo "opmodel.dev/modules/test/podinfo@v0"
+	podinfo "testing.opmodel.dev/modules/cli/podinfo@v0"
 )
 
 core.#ModuleInstance

--- a/examples/instances/podinfo/values.cue
+++ b/examples/instances/podinfo/values.cue
@@ -1,5 +1,5 @@
 // Concrete values for the podinfo instance. See the module schema at
-// opmodel.dev/modules/test/podinfo@v0 for the full #config surface.
+// testing.opmodel.dev/modules/cli/podinfo@v0 for the full #config surface.
 package podinfo
 
 values: {

--- a/hack/opm-config.cue
+++ b/hack/opm-config.cue
@@ -8,10 +8,12 @@
 package config
 
 config: {
-	// Host-side spelling of the local registry. The operator running inside the
-	// cluster uses a different address for the same registry — see
-	// KIND_CUE_REGISTRY in Taskfile.yml.
-	registry: "testing.opmodel.dev=localhost:5000+insecure,opmodel.dev=localhost:5000+insecure,registry.cue.works"
+	// Both domains resolve from GHCR: opmodel.dev carries core and the catalogs,
+	// testing.opmodel.dev this repo's own fixture modules (published by
+	// .github/workflows/publish-fixtures.yml). Matches the shipped default in
+	// internal/config/templates.go. To point the kind flow at a local registry
+	// instead, set KIND_CUE_REGISTRY — see Taskfile.yml.
+	registry: "testing.opmodel.dev=ghcr.io/open-platform-model,opmodel.dev=ghcr.io/open-platform-model,registry.cue.works"
 
 	kubernetes: {
 		kubeconfig: "~/.kube/config"

--- a/internal/config/schema/config.cue
+++ b/internal/config/schema/config.cue
@@ -18,7 +18,7 @@ package schema
 	// registry is the default registry for CUE module resolution.
 	// Can be overridden by --registry flag or OPM_REGISTRY env var.
 	// Format supports multiple registries separated by commas, with options like +insecure.
-	// Example: "opmodel.dev=localhost:5000+insecure,registry.cue.works"
+	// Example: "opmodel.dev=ghcr.io/open-platform-model,registry.cue.works"
 	registry?: string
 
 	// kubernetes contains Kubernetes-specific settings.

--- a/internal/workflow/apply/thineditor_test.go
+++ b/internal/workflow/apply/thineditor_test.go
@@ -53,7 +53,7 @@ func TestPreviewThinEditor_DescribesTheSpecEditOnly(t *testing.T) {
 	result := &workflowrender.Result{
 		Instance: pkgmodule.InstanceMetadata{Name: "podinfo", Namespace: "demo"},
 		Module: pkgmodule.ModuleMetadata{
-			ModulePath: "opmodel.dev/modules/test/podinfo@v0", Name: "podinfo", Version: "0.1.4",
+			ModulePath: "testing.opmodel.dev/modules/cli/podinfo@v0", Name: "podinfo", Version: "0.1.4",
 		},
 	}
 

--- a/internal/workflow/handoff/verify_test.go
+++ b/internal/workflow/handoff/verify_test.go
@@ -22,7 +22,7 @@ func TestAcquireFailureError_IdentityMismatch(t *testing.T) {
 	}
 	wrapped := fmt.Errorf("acquiring module: %w", idErr)
 
-	err := acquireFailureError("opmodel.dev/modules/test/podinfo@v0", "v0.1.4", wrapped)
+	err := acquireFailureError("testing.opmodel.dev/modules/cli/podinfo@v0", "v0.1.4", wrapped)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "identity mismatch")
 	assert.Contains(t, err.Error(), `declares version "v0.1.2"`)
@@ -32,7 +32,7 @@ func TestAcquireFailureError_IdentityMismatch(t *testing.T) {
 }
 
 func TestAcquireFailureError_NotFoundKeepsPublishHint(t *testing.T) {
-	err := acquireFailureError("opmodel.dev/modules/test/podinfo@v0", "v0.9.9",
+	err := acquireFailureError("testing.opmodel.dev/modules/cli/podinfo@v0", "v0.9.9",
 		fmt.Errorf("module not found"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "publish the module")

--- a/openspec/changes/fixture-testing-domain/.openspec.yaml
+++ b/openspec/changes/fixture-testing-domain/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/fixture-testing-domain/proposal.md
+++ b/openspec/changes/fixture-testing-domain/proposal.md
@@ -1,0 +1,77 @@
+# Proposal — fixture-testing-domain
+
+## Why
+
+`tests/fixtures/modules/podinfo/` declared `opmodel.dev/modules/test/podinfo@v0` — a test fixture on
+the production namespace, published nowhere. CUE routes by longest prefix on the module path, so the
+only way to reach it was to bend `opmodel.dev` itself. That is exactly what the repo did, in three
+places: `KIND_CUE_REGISTRY` pointed all of `opmodel.dev` at `opm-registry:5000`,
+`hack/opm-config.cue` at `localhost:5000`, and `examples/Taskfile.yml` carried a
+`opmodel.dev/modules/test=localhost:5000+insecure` prefix entry. The collateral was that core and the
+catalogs had to be mirrored into a laptop registry too, and `task cluster:operator` hard-required a
+running registry container before it would do anything.
+
+Two facts make the fix cheap. `gateNamespace` (`internal/publish/gates.go:258-262`) deliberately
+exempts `testing.opmodel.dev` from the owned-domain shape rules, so the new coordinate is publishable
+by `opm module publish` while the old one is *refused* (pinned at `gates_test.go:208`). And both the
+shipped CLI default (`internal/config/templates.go:9`) and the pinned operator's built-in `--registry`
+default (`opm-operator` `v1.0.0-alpha.11`, `cmd/main.go`) already route `testing.opmodel.dev` to
+GHCR — only the developer-facing mappings still said localhost.
+
+This is enhancement 0011's `registry-cleanup` slice (D17 item 3) for the CLI's own fixture. The
+operator's fleet is a separate move on its own schedule.
+
+## What Changes
+
+- **The fixture moves to `testing.opmodel.dev/modules/cli/podinfo@v0`** and becomes a real publishable
+  artifact: a new `identity/identity.cue` package is the single source of path and version, and
+  `metadata.{name,modulePath,version}` derive from it (the shape `templates/minimal` already uses).
+  Version stays `0.1.4`, so no consumer pin changes value.
+- **New `publish-fixtures.yml` workflow + `.github/scripts/publish-fixtures.sh`** publish every
+  fixture tree carrying an `identity/` package to GHCR through `opm module publish` — the same
+  pipeline and the same gates the official templates go through. Triggers: push to `main` touching
+  the fixtures, plus `workflow_dispatch` for the bootstrap/repair path. Idempotency is a caller-side
+  GHCR probe, because publish itself never skips an already-published tag (D15).
+- **Both publish scripts export `OPM_REGISTRY`, not just `CUE_REGISTRY`.** `opm` resolves
+  `--registry` > `OPM_REGISTRY` > `~/.opm/config.cue` and never consults `CUE_REGISTRY`, so the
+  existing `publish-templates.sh` was silently running against whatever the caller's personal config
+  said. It works on a CI runner that has no config and misleads everywhere else — a pre-existing
+  defect fixed alongside the new script.
+- **`pr.yml` gains a `fixture-gates` dry-run job** mirroring `template-gates`, so a fixture that would
+  fail the publish fails the PR first. Its `OPM_REGISTRY`/`CUE_REGISTRY` env gains the
+  `testing.opmodel.dev` mapping the tests now need.
+- **Every `opmodel.dev` override is deleted from the repo.** `KIND_CUE_REGISTRY` defaults to empty;
+  `hack/opm-config.cue` and `examples/Taskfile.yml` map both domains to GHCR.
+- **`cluster:operator` no longer requires a local registry.** The pinned operator ships no `--registry`
+  arg and its built-in default already routes both domains to GHCR, so the registry precondition, the
+  `docker network connect`, and the `--registry` patch all move behind an explicit `KIND_CUE_REGISTRY`
+  opt-in for iterating against a locally published module.
+- **Consumers re-pointed**: `examples/`, `tests/e2e/testdata/handoff/`, `render-parity`,
+  `ssa-ownership`, and two unit tests.
+- **Deliberately NOT changed**: the operator-owned `opmodel.dev/modules/test/{hello,hello_web,redis}`
+  fixtures and the `opmodel.dev/releases/test/*` Flux artifacts (opm-operator's move, its own
+  deviation note stays accurate); `gates_test.go:208`, which uses an `opmodel.dev/modules/test/...`
+  path as an expected *refusal* and still illustrates the rule correctly;
+  `instance-inventory`'s digest scenario, whose coordinate is an arbitrary illustration of an
+  algorithm this change does not touch.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `test-fixture-lineage`: fixtures live on the testing domain, carry an identity package, and are
+  published to GHCR rather than existing only in a local registry.
+- `ci-workflow`: a fixture publish workflow and its PR-side dry-run gate.
+- `kind-cluster-tasks`: `cluster:operator` runs against GHCR with no local registry; the
+  local-registry path is an explicit opt-in.
+
+## Impact
+
+A fresh clone can run the examples, the e2e suite, and the kind dev cluster with no registry
+container and no sibling checkout. The workspace Registry Policy (root `CLAUDE.md`) is amended in the
+same pass: `testing.opmodel.dev` is a GHCR-backed domain whose local routing is an opt-in override,
+not its definition.

--- a/openspec/changes/fixture-testing-domain/specs/ci-workflow/spec.md
+++ b/openspec/changes/fixture-testing-domain/specs/ci-workflow/spec.md
@@ -1,0 +1,42 @@
+# ci-workflow — Delta
+
+## ADDED Requirements
+
+### Requirement: Fixture modules are published to GHCR by CI
+
+A workflow SHALL publish the repository's fixture modules to GHCR through `opm module publish`, using the binary built from the commit under test so a fixture that violates any publish gate fails CI. It SHALL trigger on pushes to `main` that touch the fixture trees or the publish script, and SHALL additionally offer `workflow_dispatch` so a new coordinate can be published from a branch before the consumers that pin it merge.
+
+The workflow SHALL request `packages: write` at the job level only, and SHALL skip cleanly on forks, which cannot obtain that permission.
+
+Idempotency SHALL live in the caller: the script SHALL probe GHCR for the resolved tag and skip fixtures already published, because publish itself always refuses an already-published tag and never skips.
+
+#### Scenario: Unchanged fixture republished
+
+- **WHEN** the workflow runs and every fixture's declared version is already on GHCR
+- **THEN** each SHALL be reported as skipped by the caller-side filter and the workflow SHALL succeed
+
+#### Scenario: Bumped fixture publishes
+
+- **WHEN** a fixture's identity version is bumped and the workflow runs
+- **THEN** that fixture SHALL be published at its new tag
+
+#### Scenario: Fork run
+
+- **WHEN** the workflow triggers on a fork
+- **THEN** the publish job SHALL be skipped rather than fail on a missing token
+
+### Requirement: Fixture publish gates run on every pull request
+
+The PR workflow SHALL run the fixture publish gates in dry-run mode, without pushing, so a fixture that would fail the publish workflow fails the pull request first. A dry run whose only refusal is already-published SHALL pass, since a PR's committed version may legitimately be live; any other refusal SHALL fail the job.
+
+The PR workflow's registry mapping SHALL route `testing.opmodel.dev` to GHCR, as the fixtures the tests resolve live there.
+
+#### Scenario: Fixture with a gate violation
+
+- **WHEN** a PR makes a fixture's `metadata.modulePath` disagree with its identity package
+- **THEN** the fixture-gates job SHALL fail, naming the disagreement
+
+#### Scenario: Fixture at an already-published version
+
+- **WHEN** a PR touches a fixture without bumping its version
+- **THEN** the fixture-gates job SHALL treat the already-published refusal as acceptable and pass

--- a/openspec/changes/fixture-testing-domain/specs/kind-cluster-tasks/spec.md
+++ b/openspec/changes/fixture-testing-domain/specs/kind-cluster-tasks/spec.md
@@ -1,0 +1,40 @@
+# kind-cluster-tasks — Delta
+
+## ADDED Requirements
+
+### Requirement: Operator install task needs no local registry
+
+The `cluster:operator` task SHALL install the pinned operator into the kind cluster and SHALL NOT require a local registry container to do so. Everything the flow resolves — core, the catalogs, and this repository's fixture modules — is published on GHCR, and the pinned operator's built-in `--registry` default routes both `opmodel.dev/*` and `testing.opmodel.dev/*` there.
+
+The task SHALL remain idempotent, SHALL apply the cluster `Platform` singleton and the dev-only RBAC grant, and SHALL confirm the operator is genuinely reconciling by waiting for `status.operatorVersion` on `Platform/cluster` rather than for pod readiness alone.
+
+#### Scenario: Install with no registry container running
+
+- **WHEN** a developer runs `task cluster:operator` against a running kind cluster with no `opm-registry` container
+- **THEN** the task SHALL install the operator, apply the Platform and RBAC, and report the reconciling operator version
+
+#### Scenario: Re-run is a no-op
+
+- **WHEN** `task cluster:operator` is run a second time
+- **THEN** it SHALL complete without error and without duplicating container arguments
+
+### Requirement: Local registry is an explicit opt-in for the kind flow
+
+Pointing the kind flow at a local registry SHALL require setting `KIND_CUE_REGISTRY` explicitly. That variable SHALL default to empty. When it is set, and only then, the task SHALL verify the registry container is running, join it to kind's docker network, and append `--registry` to the operator Deployment's container arguments — appending only if no `--registry` argument is already present.
+
+The operator's registry is a command-line flag, not an environment variable: `--registry` wins over `OPM_REGISTRY`, which is read only when the flag is empty, and the operator overwrites `CUE_REGISTRY` in its own process environment. Setting either as a pod environment variable has no effect.
+
+#### Scenario: Opt-in with the registry running
+
+- **WHEN** `task cluster:operator KIND_CUE_REGISTRY='testing.opmodel.dev=opm-registry:5000+insecure,...'` runs and the registry container is up
+- **THEN** the container is joined to kind's network and the operator Deployment is patched with the matching `--registry` argument
+
+#### Scenario: Opt-in without the registry running
+
+- **WHEN** `KIND_CUE_REGISTRY` is set and no registry container is running
+- **THEN** the task SHALL fail with a message naming `task registry:start` and the option of unsetting the variable to use GHCR
+
+#### Scenario: Default path reports its registry source
+
+- **WHEN** `task cluster:operator` runs with `KIND_CUE_REGISTRY` unset
+- **THEN** the task SHALL state that the operator's built-in GHCR default is in use and SHALL NOT patch the Deployment

--- a/openspec/changes/fixture-testing-domain/specs/test-fixture-lineage/spec.md
+++ b/openspec/changes/fixture-testing-domain/specs/test-fixture-lineage/spec.md
@@ -1,0 +1,29 @@
+# test-fixture-lineage — Delta
+
+## ADDED Requirements
+
+### Requirement: Fixtures live on the testing domain and are published
+
+A test fixture module SHALL declare a module path under `testing.opmodel.dev/modules/cli/`, and SHALL NOT declare one under `opmodel.dev/`. Each fixture tree SHALL carry an `identity/` package as the single source of its path and version, with `metadata.name`, `metadata.modulePath`, and `metadata.version` derived from it. Fixture trees SHALL be published to GHCR by repository CI through `opm module publish`, so every consumer — examples, e2e testdata, the kind dev cluster, a fresh clone — resolves them from a public registry with no local registry involved.
+
+The rule is mechanical, not stylistic: CUE resolves modules by longest-prefix match on the module path, so a fixture declared under `opmodel.dev/` forces that entire prefix — core and the catalogs included — onto whatever registry serves the fixture.
+
+#### Scenario: No fixture occupies the production namespace
+
+- **WHEN** `tests/fixtures/modules/*/cue.mod/module.cue` is inspected
+- **THEN** every declared `module:` path SHALL begin with `testing.opmodel.dev/modules/cli/`
+
+#### Scenario: A fixture passes the publish gates
+
+- **WHEN** `opm module publish --dry-run` runs over a fixture tree
+- **THEN** the plan SHALL resolve with no refusals, deriving the registry repository and tag from the fixture's own identity package
+
+#### Scenario: Consumers resolve fixtures without a local registry
+
+- **WHEN** the examples, the e2e testdata, or an integration program resolves its fixture module with only the default GHCR registry mapping configured and no local registry running
+- **THEN** resolution SHALL succeed
+
+#### Scenario: A version bump is an identity edit
+
+- **WHEN** a fixture's version changes
+- **THEN** the edit SHALL be to that fixture's `identity/identity.cue`, and every consumer naming the version SHALL be re-pinned to match

--- a/openspec/changes/fixture-testing-domain/tasks.md
+++ b/openspec/changes/fixture-testing-domain/tasks.md
@@ -1,0 +1,69 @@
+# Tasks — fixture-testing-domain
+
+## 1. Fixture becomes a publishable artifact
+
+- [x] 1.1 Add `tests/fixtures/modules/podinfo/identity/identity.cue` declaring
+      `ModulePath: "testing.opmodel.dev/modules/cli/podinfo@v0"` and `Version: #VersionType | *"0.1.4"`,
+      with no release-please marker (the fixture is hand-versioned).
+- [x] 1.2 Rename `cue.mod/module.cue`'s `module:` to the same coordinate.
+- [x] 1.3 Derive `metadata.{name,modulePath,version}` from the identity package in `module.cue`
+      (the `templates/minimal` shape); rewrite the provenance header as a deliberate fork.
+- [x] 1.4 `cue vet ./...` clean and `cue eval ./identity --out text -e Version` reports `0.1.4`.
+- [x] 1.5 `opm module publish --dry-run` resolves with no refusals.
+
+## 2. Publish pipeline
+
+- [x] 2.1 Add `.github/scripts/publish-fixtures.sh` — identity-driven, repo derived from `ModulePath`,
+      caller-side GHCR already-published filter, `--dry-run` mode tolerating only the
+      already-published refusal.
+- [x] 2.2 Add `.github/workflows/publish-fixtures.yml` — push to `main` on fixture paths plus
+      `workflow_dispatch`, job-level `packages: write`, fork guard.
+- [x] 2.3 Add the `fixture-gates` dry-run job to `pr.yml` and map `testing.opmodel.dev` in its
+      registry env.
+- [x] 2.4 Export `OPM_REGISTRY` alongside `CUE_REGISTRY` in both publish scripts. `opm` resolves
+      `--registry` > `OPM_REGISTRY` > `~/.opm/config.cue` and never reads `CUE_REGISTRY`
+      (`internal/config/resolver.go:44-74`), so exporting only the latter silently left the binary
+      on the caller's personal config. Pre-existing in `publish-templates.sh`, fixed in the same
+      pass; verified by driving the dry-run against a registry where the tag exists and confirming
+      the already-published branch fires.
+
+## 3. Consumers
+
+- [x] 3.1 Re-point `examples/` (cue.mod deps, instance import, values comment, README prose).
+- [x] 3.2 Re-point `tests/e2e/testdata/handoff/` (cue.mod deps, import, header comment).
+- [x] 3.3 Re-point `tests/integration/{render-parity,ssa-ownership}/main.go`.
+- [x] 3.4 Re-point `internal/workflow/apply/thineditor_test.go` and
+      `internal/workflow/handoff/verify_test.go`.
+- [x] 3.5 Leave the near-miss coordinates untouched: `modules/test_module@v0`,
+      `opmodel.dev/modules/podinfo@v0` and its golden digest, `gates_test.go:208`'s expected refusal.
+
+## 4. Collapse the registry overrides
+
+- [x] 4.1 `Taskfile.yml`: `OPM_REGISTRY` maps both domains to GHCR; `KIND_CUE_REGISTRY` defaults to
+      empty and is documented as the local-iteration opt-in.
+- [x] 4.2 `cluster:operator`: drop the registry precondition, the network connect and the `--registry`
+      patch from the default path; gate all three behind a non-empty `KIND_CUE_REGISTRY`; rewrite the
+      summary and the failure hint.
+- [x] 4.3 `hack/opm-config.cue` and `examples/Taskfile.yml` map both domains to GHCR; delete the
+      dead `opmodel.dev/modules/test=localhost` prefix entry and its deviation comment.
+- [x] 4.4 Refresh the stale localhost example in `internal/config/schema/config.cue`.
+
+## 5. Policy and records
+
+- [x] 5.1 Amend the root `CLAUDE.md` Registry Policy: canonical mapping, rule 1, rule 3 (testing
+      domain is GHCR-backed; localhost is an opt-in override; never put a fixture on `opmodel.dev`),
+      rule 5, and narrow the known-deviations note to opm-operator.
+- [x] 5.2 Update the restatements: root `Taskfile.yml`, `.tasks/config.yml`,
+      `.tasks/registry/docker.yml`, `.claude/settings.json`'s allowlisted export string.
+- [x] 5.3 Update `cli/CLAUDE.md`'s registry section and add the fixture-authoring rule.
+- [x] 5.4 Record the slice on `enhancements/0011` with a history event.
+
+## 6. Verification
+
+- [x] 6.1 `task fmt`, `go build ./...`, `go test ./internal/... ./pkg/...`.
+- [ ] 6.2 Bootstrap publish: dispatch `publish-fixtures.yml` against the branch, confirm the GHCR
+      manifest for `testing.opmodel.dev/modules/cli/podinfo:v0.1.4` returns 200.
+- [ ] 6.3 With the local registry stopped: `cd examples && task deps:update` and
+      `opm instance build ./examples/instances/podinfo/instance.cue`.
+- [ ] 6.4 With the local registry stopped: `task cluster:create && task cluster:operator`,
+      then `task test:integration` and `task test:e2e`.

--- a/tests/e2e/testdata/handoff/cue.mod/module.cue
+++ b/tests/e2e/testdata/handoff/cue.mod/module.cue
@@ -6,10 +6,13 @@ source: {
 	kind: "self"
 }
 deps: {
+	"opmodel.dev/catalogs/opm@v2": {
+		v: "v2.0.0-alpha.3"
+	}
 	"opmodel.dev/core@v2": {
 		v: "v2.0.0-alpha.4"
 	}
-	"opmodel.dev/modules/test/podinfo@v0": {
+	"testing.opmodel.dev/modules/cli/podinfo@v0": {
 		v: "v0.1.4"
 	}
 }

--- a/tests/e2e/testdata/handoff/instance.cue
+++ b/tests/e2e/testdata/handoff/instance.cue
@@ -7,13 +7,14 @@
 // module is refused outright (0006 D38), and the digest gate needs something to
 // compare against.
 //
-// Requires opmodel.dev/modules/test/podinfo@v0 v0.1.4 in the configured
-// registry (the local kind registry publishes it).
+// Requires testing.opmodel.dev/modules/cli/podinfo@v0 v0.1.4 in the configured
+// registry. It is published to GHCR by .github/workflows/publish-fixtures.yml,
+// so the default registry mapping resolves it.
 package handoff_instance
 
 import (
 	core "opmodel.dev/core@v2"
-	podinfo "opmodel.dev/modules/test/podinfo@v0"
+	podinfo "testing.opmodel.dev/modules/cli/podinfo@v0"
 )
 
 core.#ModuleInstance

--- a/tests/fixtures/modules/podinfo/components.cue
+++ b/tests/fixtures/modules/podinfo/components.cue
@@ -1,5 +1,5 @@
-// Vendored from opm-operator/test/fixtures/modules/podinfo (components.cue) —
-// see module.cue for provenance and the drift-is-acceptable rationale.
+// Forked from opm-operator/test/fixtures/modules/podinfo (components.cue) —
+// see module.cue for provenance and the drift-is-intended rationale.
 package podinfo
 
 import (

--- a/tests/fixtures/modules/podinfo/cue.mod/module.cue
+++ b/tests/fixtures/modules/podinfo/cue.mod/module.cue
@@ -1,4 +1,4 @@
-module: "opmodel.dev/modules/test/podinfo@v0"
+module: "testing.opmodel.dev/modules/cli/podinfo@v0"
 language: {
 	version: "v0.17.0"
 }

--- a/tests/fixtures/modules/podinfo/identity/identity.cue
+++ b/tests/fixtures/modules/podinfo/identity/identity.cue
@@ -1,0 +1,20 @@
+// Package identity is the single source of this module's path and version
+// (core #IdentityPackage, enhancements 0010 D38 / 0011 D12). It sits at the
+// bottom of the module's import graph — no intra-module imports, no core
+// import; validation is external (a publishing tool unifies this package
+// against core's #IdentityPackage).
+package identity
+
+// #VersionType mirrors core.#VersionType (SemVer 2.0), duplicated so this
+// package stays import-free.
+#VersionType: string & =~"^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+// ModulePath is the module's complete CUE module path, major suffix included
+// — byte-identical to cue.mod's `module:` field.
+ModulePath: "testing.opmodel.dev/modules/cli/podinfo@v0"
+
+// Version is the module's bare SemVer; its major must agree with ModulePath's.
+// Hand-managed: this fixture is not on release-please's version train, so a
+// bump is an explicit edit here (or `opm module version set`) followed by a
+// re-pin in every consumer that names the version.
+Version: #VersionType | *"0.1.4"

--- a/tests/fixtures/modules/podinfo/module.cue
+++ b/tests/fixtures/modules/podinfo/module.cue
@@ -1,28 +1,43 @@
-// Vendored from opm-operator/test/fixtures/modules/podinfo (module.cue) for the
-// render-parity integration program, so this repo's tests carry no sibling
-// checkout dependency. Byte-for-byte drift from the operator's copy is
-// acceptable by design: render-parity's correctness comes from comparing the
-// CLI and kernel render paths over the SAME fixture, not from matching the
-// operator's copy (enhancement 0006 slice C2, design LD3).
+// podinfo — the CLI's own publishable test fixture, living on the testing
+// domain (testing.opmodel.dev/modules/cli/podinfo) and published to GHCR by
+// .github/workflows/publish-fixtures.yml. Consumers resolve it from GHCR like
+// any other module: nothing here requires a local registry.
 //
-// podinfo — stateless web example module (opmodel.dev/core@v2). Renders a
-// Deployment + Service via the catalog's deployment- and service-transformers,
-// with an HTTP livenessProbe (/healthz) and readinessProbe (/readyz) on the
-// podinfo HTTP port (9898). Serves as a real-world "getting started" example a
-// newcomer can apply against a running operator to see OPM work end-to-end.
+// Forked from opm-operator/test/fixtures/modules/podinfo, which keeps its own
+// copy on its own coordinate. The two are independent artifacts and are meant
+// to drift: render-parity's correctness comes from comparing the CLI and
+// kernel render paths over the SAME fixture, not from matching the operator's
+// copy (enhancement 0006 slice C2, design LD3).
+//
+// Stateless web example module (opmodel.dev/core@v2). Renders a Deployment +
+// Service via the catalog's deployment- and service-transformers, with an HTTP
+// livenessProbe (/healthz) and readinessProbe (/readyz) on the podinfo HTTP
+// port (9898). Serves as a real-world "getting started" example a newcomer can
+// apply against a running operator to see OPM work end-to-end.
 package podinfo
 
 import (
+	"strings"
+
 	m "opmodel.dev/core@v2"
 	res "opmodel.dev/catalogs/opm/resources/v1beta1"
+
+	id "testing.opmodel.dev/modules/cli/podinfo/identity"
 )
 
 m.#Module
 
+// Module metadata — modulePath and version are the identity package's values,
+// and name is the path's leaf (enhancements 0010 D8, 0011 D12). Edit
+// identity/identity.cue, not this block.
 metadata: {
-	name:        "podinfo"
-	modulePath:  "opmodel.dev/modules/test/podinfo@v0"
-	version:     "0.1.4"
+	_segments:  strings.Split(strings.SplitN(id.ModulePath, "@", 2)[0], "/")
+	name:       _segments[len(_segments)-1]
+	modulePath: id.ModulePath
+	// Interpolated rather than referenced so the value is concrete before
+	// defaults are finalized — the registry loader's shape gate requires a
+	// concrete metadata.version, and id.Version is a defaulted disjunction.
+	version:     "\(id.Version)"
 	description: "Stateless web example — Deployment + Service with HTTP liveness/readiness probes"
 }
 

--- a/tests/integration/render-parity/main.go
+++ b/tests/integration/render-parity/main.go
@@ -16,7 +16,7 @@
 // per-actor label is the KNOWN delta, load-path equivalence is what this
 // check proves (local staging ≡ registry acquisition; D37/D6).
 //
-// Requires: registry serving opmodel.dev/modules/test/podinfo@v0 at the
+// Requires: registry serving testing.opmodel.dev/modules/cli/podinfo@v0 at the
 // fixture's version, the catalogs, and core — SKIPs otherwise unless
 // OPM_ITEST_RENDER_PARITY=1 forces a hard failure.
 //
@@ -44,11 +44,12 @@ import (
 )
 
 const (
-	// moduleDir is repo-local (vendored from opm-operator — see the fixture's
-	// module.cue header) so render-parity runs in a standalone clone with no
-	// sibling checkout. Resolved relative to the repo root, the program's cwd.
+	// moduleDir is repo-local (forked from opm-operator's copy — see the
+	// fixture's module.cue header) so render-parity runs in a standalone clone
+	// with no sibling checkout. Resolved relative to the repo root, the
+	// program's cwd.
 	moduleDir     = "tests/fixtures/modules/podinfo"
-	modulePath    = "opmodel.dev/modules/test/podinfo@v0"
+	modulePath    = "testing.opmodel.dev/modules/cli/podinfo@v0"
 	moduleVersion = "v0.1.4"
 	instName      = "podinfo-parity"
 	instNamespace = "default"

--- a/tests/integration/ssa-ownership/main.go
+++ b/tests/integration/ssa-ownership/main.go
@@ -46,7 +46,7 @@ const (
 	clusterContext = "kind-opm-dev"
 	instanceName   = "ssa-ownership-itest"
 	namespace      = "default"
-	modulePath     = "opmodel.dev/modules/test/podinfo@v0"
+	modulePath     = "testing.opmodel.dev/modules/cli/podinfo@v0"
 	moduleVersion  = "v0.1.4"
 )
 


### PR DESCRIPTION
## Why

`tests/fixtures/modules/podinfo/` declared `opmodel.dev/modules/test/podinfo` — a test fixture on the production namespace, published nowhere. CUE routes by longest prefix on the module path, so the only way to reach it was to bend `opmodel.dev` itself. Three places did exactly that:

- `Taskfile.yml`'s `KIND_CUE_REGISTRY` → all of `opmodel.dev` at `opm-registry:5000`
- `hack/opm-config.cue` → all of `opmodel.dev` at `localhost:5000`
- `examples/Taskfile.yml` → an `opmodel.dev/modules/test=localhost:5000+insecure` prefix entry

The collateral was that `opmodel.dev/core` and `opmodel.dev/catalogs/opm` had to be mirrored into a laptop registry too (both were present in mine), and `task cluster:operator` hard-required a running registry container before it would do anything.

## What changed

**The fixture** is now `testing.opmodel.dev/modules/cli/podinfo`, with an `identity/` package as the single source of path and version and `metadata.{name,modulePath,version}` derived from it — the shape `templates/minimal` already uses. Version stays `0.1.4`, so no consumer pin changes value. `gateNamespace` deliberately exempts the testing domain, so the new coordinate passes every publish gate where the old one is refused.

**Publishing**: `.github/scripts/publish-fixtures.sh` + `publish-fixtures.yml` push every fixture tree carrying an `identity/` package to GHCR through `opm module publish` — the same pipeline and gates the templates go through. Triggers on `main` pushes touching the fixtures, plus `workflow_dispatch` for the bootstrap/repair path. Idempotency is a caller-side GHCR probe, since publish itself never skips an already-published tag. `pr.yml` gains a matching `fixture-gates` dry-run job.

**All three overrides are deleted.** `KIND_CUE_REGISTRY` defaults to empty; `hack/opm-config.cue` and `examples/Taskfile.yml` map both domains to GHCR.

**`cluster:operator` no longer needs a local registry.** The pinned operator (`v1.0.0-alpha.11`) ships no `--registry` arg and its built-in default already routes both domains to GHCR — verified against the release tag, not just the working tree. The registry precondition, the `docker network connect` and the `--registry` patch all move behind an explicit `KIND_CUE_REGISTRY` opt-in for iterating against a locally published module.

## Bug found along the way

`publish-templates.sh` exported only `CUE_REGISTRY`, but `opm` resolves `--registry` > `OPM_REGISTRY` > `~/.opm/config.cue` and **never reads `CUE_REGISTRY`** (`internal/config/resolver.go:44-74`). The script has been publishing against whatever the caller's personal config named — it works on a CI runner because there is no config there, and misleads everywhere else. Fixed in its own commit; the new script exports both.

## Merge order

The renamed coordinate does not exist on GHCR yet, so **dispatch `publish-fixtures.yml` against this branch before merging**. Until then anything resolving the fixture from a pure-GHCR mapping fails with `module not found` — the expected pre-bootstrap state.

## Verification

- `task fmt` / `go build` / `task lint` (0 issues) / unit tests — green
- `task test:e2e` — pass (166s)
- `opm module publish --dry-run` on the new coordinate — GO, no refusals
- Both dry-run branches exercised: fresh coordinate → GO; already-published → the acceptable-refusal path
- Fixture published to a local registry under the testing domain; `opm instance build` on the example renders Deployment + Service correctly
- `render-parity` — local staging and registry acquisition byte-identical (`sha256:968b39cb…`)
- `ssa-ownership` — pass
- `task cluster:operator` against a live kind cluster with no registry involvement — installs, skips the patch, reports the operator reconciling
- The opt-in guard refuses correctly when `KIND_CUE_REGISTRY` is set and no registry container is running

Not verified: the GHCR publish itself, which is what the bootstrap dispatch above covers.

## Out of scope

The operator-owned `opmodel.dev/modules/test/{hello,hello_web,redis}` fixtures and the `opmodel.dev/releases/test/*` Flux artifacts stay where they are — opm-operator publishes those, and its own deviation note remains accurate. `gates_test.go:208` keeps its `opmodel.dev/modules/test/...` path as an expected *refusal*, which still illustrates the rule.

Recorded as OpenSpec change `fixture-testing-domain` (3 delta specs) and as enhancement 0011's `registry-cleanup` slice, which moves to in-progress.

The workspace Registry Policy in the root `CLAUDE.md` is amended in the same pass — rule 3 previously said the testing domain was the *only* prefix routed to localhost, which is what made a GHCR-published fixture read as a violation. That file is not in any git repo, so it is not part of this PR.
